### PR TITLE
Control host automation

### DIFF
--- a/DedicatedServer/HostAutomatorStages/ProcessPauseBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/ProcessPauseBehaviorLink.cs
@@ -13,32 +13,177 @@ namespace DedicatedServer.HostAutomatorStages
 {
     internal class ProcessPauseBehaviorLink : BehaviorLink
     {
-        private bool paused = false;
+        /// <summary>
+        ///         This allows you to deactivate the execution of host automation. Default is true
+        /// <br/>   
+        /// <br/>   true : The normal behavior of this mod is running
+        /// <br/>   false: Keeps the behavior of the mod as it would be in the paused state
+        /// <br/>   
+        /// <br/>   Works only if <see cref="AutomatedHost"/> ticks and the <see cref="BehaviorChain"/> is executed.
+        /// </summary>
+        protected static bool enableHostAutomation = true;
+
+        /// <summary>
+        ///         Prevents the pause state. Default is false
+        /// <br/>   
+        /// <br/>   true : The server never switches to pause mode
+        /// <br/>   false: The normal behavior of this mod is running
+        /// </summary>
+        protected static bool preventPause = false;
+
+        private bool IsPaused
+        {
+            set { Game1.netWorldState.Value.IsPaused = value; }
+            get { return Game1.netWorldState.Value.IsPaused; }
+        }
 
         public ProcessPauseBehaviorLink(BehaviorLink next = null) : base(next)
         {
         }
 
+        private enum internalStates
+        {
+            /// <summary> The server runs as long as players are online </summary>
+            WaitingForPlayersToLeave = 0,
+
+            /// <summary> Transitional action, enables pause </summary>
+            EnablePause,
+
+            /// <summary> The server is paused as long as no players are online </summary>
+            WaitingForUpcomingPlayers,
+
+            /// <summary> Transitional action, disables pause </summary>
+            DisablePause,
+
+
+            /// <summary> Transitional action, disables pause </summary>
+            PreparePreventPause,
+
+            /// <summary>
+            ///         Prevents the pause state. You can switch to this state 
+            /// <br/>   from any state and switch back to the original state.
+            /// </summary>
+            PreventPause,
+
+
+            /// <summary>
+            ///         If the server is running, you can pause the game by setting
+            /// <br/>   <see cref="Game1.netWorldState.Value.IsPaused"/> to true.
+            /// <br/>   To go back, the same value must be set to false.
+            /// <br/>   
+            /// <br/>   So you can come from state <see cref="WaitingForPlayersToLeave"/>
+            /// <br/>   to this one and go back.
+            /// </summary>
+            ExternalPause,
+
+            /// <summary>
+            ///         If the server is paused, you can run the game by setting
+            /// <br/>   <see cref="Game1.netWorldState.Value.IsPaused"/> to false.
+            /// <br/>   To go back, the same value must be set to true.
+            /// <br/>   
+            /// <br/>   So you can come from state <see cref="WaitingForUpcomingPlayers"/>
+            /// <br/>   to this one and go back.
+            /// </summary>
+            ExternalPauseDisabled,
+        }
+
+        private internalStates internalState = internalStates.WaitingForPlayersToLeave;
+
+        private internalStates saveInternalState;
+        private bool saveIsPaused;
+
         public override void Process(BehaviorState state)
         {
-            if (!Game1.netWorldState.Value.IsPaused)
+            if (preventPause && 
+                internalStates.PreventPause != internalState)
             {
-                paused = false;
+                saveInternalState = internalState;
+                saveIsPaused = IsPaused;
+                internalState = internalStates.PreparePreventPause;
             }
 
-            if (state.GetNumOtherPlayers() == 0 && !Game1.isFestival() && !Game1.netWorldState.Value.IsPaused)
+            switch (internalState)
             {
-                paused = true;
-                Game1.netWorldState.Value.IsPaused = true;
-            }
-            else if ((state.GetNumOtherPlayers() > 0 && paused) || (Game1.isFestival() && Game1.netWorldState.Value.IsPaused))
-            {
-                paused = false;
-                Game1.netWorldState.Value.IsPaused = false;
-            }
-            else if (!Game1.netWorldState.Value.IsPaused)
-            {
-                processNext(state);
+                case internalStates.WaitingForPlayersToLeave:
+                    if (IsPaused)
+                    {
+                        internalState = internalStates.ExternalPause;
+                        return; 
+                    }
+
+                    if (  0   == state.GetNumOtherPlayers() && // If no other player is online
+                        false == Game1.isFestival()         )  // if it is not a festival
+                    {
+                        internalState = internalStates.EnablePause;
+                        return;
+                    }
+                    if (enableHostAutomation)
+                    {
+                        processNext(state);
+                    }
+                    return;
+
+                case internalStates.EnablePause:
+                    IsPaused = true;
+                    internalState = internalStates.WaitingForUpcomingPlayers;
+                    return;
+
+                case internalStates.WaitingForUpcomingPlayers:
+                    if (false == IsPaused)
+                    {
+                        internalState = internalStates.ExternalPauseDisabled;
+                        return;
+                    }
+
+                    if (  0  <  state.GetNumOtherPlayers() || 
+                        true == Game1.isFestival()         )
+                    {
+                        internalState = internalStates.DisablePause;
+                    }
+                    return;
+
+                case internalStates.DisablePause:
+                    IsPaused = false;
+                    internalState = internalStates.WaitingForPlayersToLeave;
+                    return;
+
+                case internalStates.PreparePreventPause:
+                    IsPaused = false;
+                    internalState = internalStates.PreventPause;
+                    goto case internalStates.PreventPause;
+
+                case internalStates.PreventPause:
+                    if (false == preventPause)
+                    {
+                        internalState = saveInternalState;
+                        IsPaused = saveIsPaused;
+                        return;
+                    }
+                    if (enableHostAutomation)
+                    {
+                        processNext(state);
+                    }
+                    return;
+
+                case internalStates.ExternalPause:
+                    if (false == IsPaused)
+                    {
+                        internalState = internalStates.WaitingForPlayersToLeave;
+                        return;
+                    }
+                    return;
+
+                case internalStates.ExternalPauseDisabled:
+                    if (true == IsPaused)
+                    {
+                        internalState = internalStates.WaitingForUpcomingPlayers;
+                        return;
+                    }
+                    if (enableHostAutomation)
+                    {
+                        processNext(state);
+                    }
+                    return;
             }
         }
     }

--- a/DedicatedServer/Utils/HostAutomation.cs
+++ b/DedicatedServer/Utils/HostAutomation.cs
@@ -1,0 +1,39 @@
+﻿using DedicatedServer.HostAutomatorStages;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DedicatedServer.Utils
+{
+    internal abstract class HostAutomation : ProcessPauseBehaviorLink
+    {
+        /// <summary>
+        /// Alias for <c>Game1.netWorldState.Value.IsPaused</c>
+        /// </summary>
+        public static bool IsPaused
+        {
+            get { return Game1.netWorldState.Value.IsPaused; }
+            set { Game1.netWorldState.Value.IsPaused = value; }
+        }
+        /// <summary>
+        /// <inheritdoc cref = "ProcessPauseBehaviorLink.preventPause"/>
+        /// </summary>
+        public static bool PreventPause
+        {
+            get { return ProcessPauseBehaviorLink.preventPause; }
+            set { ProcessPauseBehaviorLink.preventPause = value; }
+        }
+
+        /// <summary>
+        /// <inheritdoc cref = "ProcessPauseBehaviorLink.enableHostAutomation"/>
+        /// </summary>
+        public static bool EnableHostAutomation
+        {
+            get { return ProcessPauseBehaviorLink.enableHostAutomation; }
+            set { ProcessPauseBehaviorLink.enableHostAutomation = value; }
+        }
+    }
+}

--- a/DedicatedServer/Utils/Invincible.cs
+++ b/DedicatedServer/Utils/Invincible.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace DedicatedServer.Utils
 {
-    internal class Invincible : InvincibleWorker
+    internal abstract class Invincible : InvincibleWorker
     {
         private Invincible() : base(null)
         {


### PR DESCRIPTION
`HostAutomation` class added:
- With the alias `IsPaused`, to read and write `Game1.netWorldState.Value.IsPaused`
- With the `PreventPause` property to prevent any pause.
- `EnableHostAutomation` to stop the DedicatedServer functions as if the server is in paused mode.

Previously there was inconsistent behavior, now you can set `Game1.netWorldState.Value.IsPaused` to false when the game is paused by the `ProcessPauseBehaviorLink` class to resume the game.
- You can play/debug with the host without a client if `Game1.netWorldState.Value.IsPaused` is set to false or if the `HostAutomation.PreventPause` property is set to true. A chat command is currently not built in.