### PR TITLE
Fixed bug when the host receives something but inventory is full

### DIFF
--- a/DedicatedServer/HostAutomatorStages/ProcessDialogueBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/ProcessDialogueBehaviorLink.cs
@@ -1,6 +1,9 @@
 ﻿using DedicatedServer.Config;
+using DedicatedServer.Utils;
 using StardewValley;
 using StardewValley.Menus;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace DedicatedServer.HostAutomatorStages
@@ -124,6 +127,45 @@ namespace DedicatedServer.HostAutomatorStages
                     itemListMenuInfo?.Invoke(ilm, new object[] { });
                     state.SkipDialogue();
                 }
+                else if (Game1.activeClickableMenu is ItemGrabMenu igm)
+                {
+                    // Good to test when you go into the mine and are presented with a sword
+
+                    var count = igm.ItemsToGrabMenu.actualInventory.Count();
+
+                    if (false == ServerHost.EnsureFreeSlotNumber(count))
+                    {
+                        // Try again later
+                        return;
+                    }
+
+                    var del = new List<Item>();
+                    foreach (var item in igm.ItemsToGrabMenu.actualInventory)
+                    {
+                        if(null == item) { continue; }
+
+                        Game1.player.addItemToInventoryBool(item);
+                        del.Add(item);
+                    }
+
+                    foreach (var item in del)
+                    {
+                        igm.ItemsToGrabMenu.actualInventory.Remove(item);
+                    }
+
+                    if(false == igm.areAllItemsTaken())
+                    {
+                        // Drop all remaining items from the menu
+                        igm.DropRemainingItems();
+                    }
+
+                    if (igm.readyToClose())
+                    {
+                        okClicked();
+                    }
+
+                    state.SkipDialogue();
+                }
                 else
                 {
                     state.ClearBetweenDialoguesWaitTicks();
@@ -135,6 +177,17 @@ namespace DedicatedServer.HostAutomatorStages
                 state.ClearBetweenDialoguesWaitTicks();
                 processNext(state);
             }
+        }
+
+        private void okClicked()
+        {
+            Game1.activeClickableMenu = null;
+            if (Game1.CurrentEvent != null)
+            {
+                Game1.CurrentEvent.CurrentCommand++;
+            }
+
+            Game1.playSound("bigDeSelect");
         }
     }
 }

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -2,13 +2,11 @@
 using DedicatedServer.Config;
 using DedicatedServer.Utils;
 using StardewModdingAPI;
-using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Locations;
 using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 
 namespace DedicatedServer.MessageCommands
@@ -57,6 +55,15 @@ namespace DedicatedServer.MessageCommands
 
                     #region DEBUG_COMMANDS
                     #if false
+
+                    case "emptyinventoryall": // /message serverbot EmptyInventoryAll
+                        ServerHost.EmptyHostInventory();
+                        break;
+
+                    case "menu":
+                        var menu = Game1.activeClickableMenu;
+                        chatBox.textBoxEnter($" Menu is {(menu?.ToString() ?? "")}" + TextColor.Green);
+                        break;
 
                     case "letmecontrol":
                         HostAutomation.LetMeControl();
@@ -140,7 +147,10 @@ namespace DedicatedServer.MessageCommands
                         chatBox.textBoxEnter($"The host will go to sleep." + TextColor.Green);
                         Sleeping.ShouldSleepOverwrite = true;
                     }
-                    
+                    break;
+
+                case "forcesleep": // /message ServerBot ForcedSleep
+                    RestartDay.ForcedSleep((seconds) => chatBox.textBoxEnter($"Attention: Server will reset the day in {seconds} seconds" + TextColor.Orange));
                     break;
 
                 case "resetday": // /message ServerBot ResetDay

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -149,15 +149,15 @@ namespace DedicatedServer.MessageCommands
                     }
                     break;
 
-                case "forcesleep": // /message ServerBot ForcedSleep
-                    RestartDay.ForcedSleep((seconds) => chatBox.textBoxEnter($"Attention: Server will reset the day in {seconds} seconds" + TextColor.Orange));
+                case "forcesleep": // /message ServerBot ForceSleep
+                    RestartDay.ForceSleep((seconds) => chatBox.textBoxEnter($"Attention: Server will reset the day in {seconds} seconds" + TextColor.Orange));
                     break;
 
-                case "resetday": // /message ServerBot ResetDay
+                case "forceresetday": // /message ServerBot ForceResetDay
                     RestartDay.ResetDay((seconds) => chatBox.textBoxEnter($"Attention: Server will reset the day in {seconds} seconds" + TextColor.Orange));
                     break;
 
-                case "shutdown": // /message ServerBot Shutdown
+                case "forceshutdown": // /message ServerBot ForceShutDown
                     RestartDay.ShutDown((seconds) => chatBox.textBoxEnter($"Attention: Server will shut down in {seconds} seconds" + TextColor.Orange));
                     break;
 

--- a/DedicatedServer/Utils/Host.cs
+++ b/DedicatedServer/Utils/Host.cs
@@ -1,0 +1,127 @@
+﻿using StardewValley.Menus;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DedicatedServer.Chat;
+using DedicatedServer.Config;
+using StardewModdingAPI;
+using StardewValley.Minigames;
+
+namespace DedicatedServer.Utils
+{
+    internal class ServerHost
+    {        
+        private static EventDrivenChatBox chatBox;
+
+        public ServerHost(EventDrivenChatBox chatBox)
+        {
+            ServerHost.chatBox = chatBox;
+        }
+
+        /// <summary>
+        ///         Empty the host inventory, tools are not deleted
+        /// </summary>
+        static public void EmptyHostInventory()
+        {
+            for (int i = Game1.player.Items.Count - 1; i >= 0; i--)
+            {
+                var item = Game1.player.Items[i];
+
+                if (null == item) continue;
+
+                if (item.canBeTrashed())
+                {
+                    chatBox?.textBoxEnter($" Item {item.Name} deleted");
+                    Game1.player.removeItemFromInventory(item);
+                }
+            }
+        }
+
+        /// <summary>
+        ///         Ensure that a number of free slots are available
+        /// </summary>
+        /// <param name="numberOfFreeSlot"></param>
+        /// <returns>The result of the method:
+        /// <br/>   true : The requested slots are free
+        /// <br/>   false: The requested slots could not be provided</returns>
+        static public bool EnsureFreeSlotNumber(int numberOfFreeSlot)
+        {
+            for (int i = Game1.player.Items.Count - 1; i >= 0; i--)
+            {
+                var item = Game1.player.Items[i];
+
+                if (null == item)
+                {
+                    numberOfFreeSlot--;
+                }
+                else
+                {
+                    if (item.canBeTrashed())
+                    {
+                        chatBox?.textBoxEnter($" Item {item.Name} deleted");
+                        Game1.player.removeItemFromInventory(item);
+                        numberOfFreeSlot--;
+                    }
+                }
+
+                if(numberOfFreeSlot <= 0)
+                {
+                    break;
+                }
+            }
+
+            if(0 < numberOfFreeSlot)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        ///         Deletes the last set of items when the inventory is full
+        /// <br/>   Goes from right to left, tools are not deleted
+        /// </summary>
+        static public void ClearLastItem()
+        {
+            if (Game1.player.isInventoryFull())
+            {
+                for (int i = Game1.player.Items.Count - 1; i >= 0; i--)
+                {
+                    var item = Game1.player.Items[i];
+
+                    if (null == item) continue;
+
+                    if (item.canBeTrashed())
+                    {
+                        chatBox?.textBoxEnter($" Item {item.Name} dumped");
+                        Game1.player.removeItemFromInventory(item);
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///         Closes all open menus
+        /// </summary>
+        static public void ForceClosingAllMenu()
+        {
+            while (null != Game1.activeClickableMenu)
+            {
+                Game1.activeClickableMenu = null;
+                if (Game1.CurrentEvent != null)
+                {
+                    Game1.CurrentEvent.CurrentCommand++;
+                }
+
+                Game1.playSound("bigDeSelect");
+            }
+        }
+    }
+}

--- a/DedicatedServer/Utils/RestartDay.cs
+++ b/DedicatedServer/Utils/RestartDay.cs
@@ -20,7 +20,7 @@ namespace DedicatedServer.Utils
         /// <param name="action">
         ///         Function that is executed every second until the
         /// <br/>   event is executed. The parameter is the remaining time.</param>
-        public static void ForcedSleep(Action<int> action)
+        public static void ForceSleep(Action<int> action)
         {
             RestartDayWorker.SavesGameRestartsDay(
                 time: 10,

--- a/DedicatedServer/Utils/RestartDay.cs
+++ b/DedicatedServer/Utils/RestartDay.cs
@@ -15,6 +15,21 @@ namespace DedicatedServer.Utils
         }
 
         /// <summary>
+        ///         Kicks all players and starts the next day
+        /// </summary>
+        /// <param name="action">
+        ///         Function that is executed every second until the
+        /// <br/>   event is executed. The parameter is the remaining time.</param>
+        public static void ForcedSleep(Action<int> action)
+        {
+            RestartDayWorker.SavesGameRestartsDay(
+                time: 10,
+                keepsCurrentDay: false,
+                quit: false,
+                action: action);
+        }
+
+        /// <summary>
         ///         Kicks all players and restarts the day
         /// </summary>
         /// <param name="action">

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ All commands in the game must be sent privately to the player `ServerBot`. For e
 - `InviteCode`: The invitation code is printed.
 - `Sleep`: (Toggle command) \
   When it is sent, the host goes to bed. When all players leave the game or go to bed, the next day begins. On a second send, the host will get up and the mod's normal behavior will be restored.
-- `ResetDay`: Kicks all players and restarts the day.
-- `Shutdown`: Kicks all players and starts a new day.
+- `ForceSleep`: Kick out all players and starts a new day.
+- `ForceResetDay`: Kick out all players and restarts the day.
+- `ForceShutDown`: Kick out all players, start a new day and shut down the server.
 - `SpawnMonster`: (Toggle command, Saved in config) \
   Changes the settings so that monsters spawn on the farm or not. Spawned monsters are not reset.
 - `MoveBuildPermission` or


### PR DESCRIPTION
- Added helper methods for cleaning up the hosts inventory:
  - `EmptyHostInventory`
  - `EnsureFreeSlotNumber`
  - `ClearLastItem`
  - `ForceClosingAllMenu`
- Handles the `ItemGrabMenu` menu:
  - Deletes as many items from a full inventory as is necessary to take all the items on offer.
  - Takes all items.
  - If this is not possible, the remaining items are deleted
  - Closes the dialog.
- Added `ForcedSleep` command
  - Kick out all players and
  - start the next day.