### PR TITLE
Task host farmhouse upgrade

### DIFF
--- a/DedicatedServer/Config/ModConfig.cs
+++ b/DedicatedServer/Config/ModConfig.cs
@@ -77,6 +77,16 @@ namespace DedicatedServer.Config
         public bool TryActivatingInviteCode { get; set; } = true;
 
         /// <summary>
+        ///         If this option is set to true, the upgrade level of the host's farmhouse
+        /// <br/>   changes to the same, highest upgrade level of all farmers.
+        /// <br/>   
+        /// <br/>   With <see cref="DedicatedServer.Utils.HostHouseUpgrade.ManualUpdate(string)"/> 
+        /// <br/>   you can downgrade or upgrade it manually. As long as this property is set to true,
+        /// <br/>   the house is automatically upgraded again.
+        /// </summary>
+        public bool UpgradeHostHouseWithFarmhand { get; set; } = false;
+
+        /// <summary>
         ///         Password used to log in
         /// <br/>
         /// <br/>   Must be changed to a secure password

--- a/DedicatedServer/Config/ModConfig.cs
+++ b/DedicatedServer/Config/ModConfig.cs
@@ -84,7 +84,7 @@ namespace DedicatedServer.Config
         /// <br/>   you can downgrade or upgrade it manually. As long as this property is set to true,
         /// <br/>   the house is automatically upgraded again.
         /// </summary>
-        public bool UpgradeHostHouseWithFarmhand { get; set; } = false;
+        public bool UpgradeHouseLevelBasedOnFarmhand { get; set; } = false;
 
         /// <summary>
         ///         Password used to log in
@@ -191,7 +191,7 @@ namespace DedicatedServer.Config
         /// <summary>
         /// <seealso cref="MessageCommands.ServerCommandListener"/>
         /// </summary>
-        public bool UpgradeHostHouseWithFarmhand { get; set; } = true;
+        public bool UpgradeHouseLevelBasedOnFarmhand { get; set; } = true;
         
     }
 }

--- a/DedicatedServer/Config/ModConfig.cs
+++ b/DedicatedServer/Config/ModConfig.cs
@@ -187,5 +187,11 @@ namespace DedicatedServer.Config
         /// <seealso cref="MessageCommands.ServerCommandListener"/>
         /// </summary>
         public bool MoveBuildPermission { get; set; } = true;
+
+        /// <summary>
+        /// <seealso cref="MessageCommands.ServerCommandListener"/>
+        /// </summary>
+        public bool UpgradeHostHouseWithFarmhand { get; set; } = true;
+        
     }
 }

--- a/DedicatedServer/HostAutomatorStages/ReadyCheckHelper.cs
+++ b/DedicatedServer/HostAutomatorStages/ReadyCheckHelper.cs
@@ -48,7 +48,7 @@ namespace DedicatedServer.HostAutomatorStages
             }
 
 
-            if (config?.UpgradeHostHouseWithFarmhand ?? false)
+            if (config?.UpgradeHouseLevelBasedOnFarmhand ?? false)
             {
                 HostHouseUpgrade.NeedsUpgrade();
             }

--- a/DedicatedServer/HostAutomatorStages/ReadyCheckHelper.cs
+++ b/DedicatedServer/HostAutomatorStages/ReadyCheckHelper.cs
@@ -1,4 +1,7 @@
 ﻿using Netcode;
+using DedicatedServer.Config;
+using DedicatedServer.Utils;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Locations;
 using StardewValley.Network;
@@ -11,7 +14,28 @@ namespace DedicatedServer.HostAutomatorStages
 {
     internal class ReadyCheckHelper
     {
-        public static void OnDayStarted(object sender, StardewModdingAPI.Events.DayStartedEventArgs e)
+        private IModHelper helper;
+        private IMonitor monitor;
+        private ModConfig config;
+
+        public ReadyCheckHelper(IModHelper helper, IMonitor monitor, ModConfig config)
+        {
+            this.helper = helper;
+            this.monitor = monitor;
+            this.config = config;
+        }
+
+        public void Enable()
+        {
+            helper.Events.GameLoop.DayStarted += OnDayStarted;
+        }
+
+        public void Disable()
+        {
+            helper.Events.GameLoop.DayStarted -= OnDayStarted;
+        }
+
+        public void OnDayStarted(object sender, StardewModdingAPI.Events.DayStartedEventArgs e)
         {
             //Checking mailbox sometimes gives some gold, but it's compulsory to unlock some events
             for (int i = 0; i < 10; ++i) {
@@ -23,11 +47,10 @@ namespace DedicatedServer.HostAutomatorStages
                 Game1.player.eventsSeen.Add("295672");
             }
 
-            //Upgrade farmhouse to match highest level cabin
-            var targetLevel = Game1.getFarm().buildings.Where(o => o.isCabin).Select(o => ((Cabin)o.indoors.Value).upgradeLevel).DefaultIfEmpty(0).Max();
-            if (targetLevel > Game1.player.HouseUpgradeLevel) {
-                Game1.player.HouseUpgradeLevel = targetLevel;
-                Game1.player.performRenovation("FarmHouse");
+
+            if (config?.UpgradeHostHouseWithFarmhand ?? false)
+            {
+                HostHouseUpgrade.NeedsUpgrade();
             }
         }
 

--- a/DedicatedServer/HostAutomatorStages/StartFarmStage.cs
+++ b/DedicatedServer/HostAutomatorStages/StartFarmStage.cs
@@ -22,6 +22,7 @@ namespace DedicatedServer.HostAutomatorStages
         private IMonitor monitor;
         private ModConfig config;
         private CropSaver cropSaver = null;
+        private ReadyCheckHelper readyCheckHelper = null;
         private PasswordValidation passwordValidation = null;
         private AutomatedHost automatedHost = null;
         private InvincibleWorker invincibleWorker = null;
@@ -33,6 +34,7 @@ namespace DedicatedServer.HostAutomatorStages
         private ServerCommandListener serverCommandListener = null;
         private MultiplayerOptions multiplayerOptions = null;
         private MoveBuildPermission moveBuildPermission = null;
+        private HostHouseUpgrade hostHouseUpgrade = null;
         private ShippingMenuCommandListener shippingMenuCommandListener = null;
         private Wallet wallet = null;
 
@@ -45,7 +47,8 @@ namespace DedicatedServer.HostAutomatorStages
                 cropSaver = new CropSaver(helper, monitor, config);
                 cropSaver.Enable();
             }
-            helper.Events.GameLoop.DayStarted += ReadyCheckHelper.OnDayStarted;
+            readyCheckHelper = new ReadyCheckHelper(helper, monitor, config);
+            readyCheckHelper.Enable();
             helper.Events.GameLoop.ReturnedToTitle += onReturnToTitle;
         }
 
@@ -355,6 +358,7 @@ namespace DedicatedServer.HostAutomatorStages
                 MultiplayerOptions.TryActivatingInviteCode();
             }
             moveBuildPermission = new MoveBuildPermission(chatBox);
+            hostHouseUpgrade = new HostHouseUpgrade(helper, monitor, config, chatBox);
             wallet = new Wallet(chatBox);
 
             buildCommandListener = new BuildCommandListener(chatBox);
@@ -384,6 +388,9 @@ namespace DedicatedServer.HostAutomatorStages
             pauseCommandListener = null;
             serverCommandListener?.Disable();
             serverCommandListener = null;
+
+            readyCheckHelper?.Disable();
+            readyCheckHelper = null;
         }
     }
 }

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -108,6 +108,14 @@ namespace DedicatedServer.MessageCommands
                         Game1.player.warpFarmer(WarpPoints.beachWarp);
                         break;
 
+                    case "robin":
+                        Game1.player.warpFarmer(WarpPoints.robinWarp);
+                        break;
+
+                    case "clint":
+                        Game1.player.warpFarmer(WarpPoints.clintWarp);
+                        break;
+
                     case "location":
                         var location = Game1.player.Tile;
                         chatBox.textBoxEnter("location: " + Game1.player.currentLocation.ToString());

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -268,12 +268,26 @@ namespace DedicatedServer.MessageCommands
         
         private void UpdateHouseLevel(Farmer farmer, string param)
         {
+            if (false == PasswordValidation.IsAuthorized(farmer.UniqueMultiplayerID, p => p.UpgradeHostHouseWithFarmhand))
+            {
+                WriteToPlayer(farmer, PasswordValidation.notAuthorizedMessage);
+                return;
+            }
+
             if ("" == param)
             {
-                HostHouseUpgrade.NeedsUpgrade();
+                if (HostHouseUpgrade.NeedsUpgrade())
+                {
+                    WriteToPlayer(null, "A host farm house upgrade is being executed" + TextColor.Yellow);
+                }
+                else
+                {
+                    WriteToPlayer(null, "A host farm house upgrade is not necessary" + TextColor.Green);
+                }
             }
             else
             {
+                WriteToPlayer(null, $"The host farm house is upgraded to {param}" + TextColor.Orange);
                 HostHouseUpgrade.ManualUpdate(param);
             }
         }

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -65,13 +65,34 @@ namespace DedicatedServer.MessageCommands
                     #region DEBUG_COMMANDS
                     #if false
 
+                    case "items":
+                        Item item;
+                        item = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
+                        Game1.player.addItemToInventory(item);
+                        item = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
+                        Game1.player.addItemToInventory(item);
+                        item = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
+                        Game1.player.addItemToInventory(item);
+                        item = new StardewValley.Object(StardewValley.Object.woodID, 999);
+                        Game1.player.addItemToInventory(item);
+                        item = new StardewValley.Object(StardewValley.Object.stoneID, 999);
+                        Game1.player.addItemToInventory(item);
+                        break;
+
+                    case "inventory":
+                        foreach(var inventoryItems in Game1.player.Items)
+                        {
+                            ;
+                        }
+                        break;
+
                     case "iridium":
                         Item itemi;
                         itemi = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
                         Game1.player.addItemToInventory(itemi);
                         break;
-                    case "wood":
 
+                    case "wood":
                         Item itemw;
                         itemw = new StardewValley.Object(StardewValley.Object.woodID, 999);
                         Game1.player.addItemToInventory(itemw);
@@ -162,6 +183,10 @@ namespace DedicatedServer.MessageCommands
                     TakeOver(sourceFarmer);
                     break;
 
+                case "updatehouselevel":  // /message ServerBot UpdateHouseLevel
+                    UpdateHouseLevel(sourceFarmer, param);
+                    break;
+
                 case "safeinvitecode": // /message ServerBot SafeInviteCode
                     SafeInviteCode(sourceFarmer);
                     break;
@@ -241,6 +266,18 @@ namespace DedicatedServer.MessageCommands
             HostAutomation.Reset();
         }
         
+        private void UpdateHouseLevel(Farmer farmer, string param)
+        {
+            if ("" == param)
+            {
+                HostHouseUpgrade.NeedsUpgrade();
+            }
+            else
+            {
+                HostHouseUpgrade.ManualUpdate(param);
+            }
+        }
+
         private void SafeInviteCode(Farmer farmer)
         {
             if (false == PasswordValidation.IsAuthorized(farmer.UniqueMultiplayerID, p => p.SafeInviteCode))

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -20,6 +20,8 @@ namespace DedicatedServer.MessageCommands
 
         private IModHelper helper;
 
+        private const string HardwoodItemId = "709";
+
         public ServerCommandListener(IModHelper helper, ModConfig config, EventDrivenChatBox chatBox)
         {
             this.helper  = helper;
@@ -50,6 +52,8 @@ namespace DedicatedServer.MessageCommands
                 .FirstOrDefault()
                 ?? Game1.player;
 
+            string param = 1 < tokens.Length ? tokens[1].ToLower() : "";
+
             if (Game1.player.UniqueMultiplayerID == e.SourceFarmerId)
             {
                 switch (command)
@@ -60,11 +64,29 @@ namespace DedicatedServer.MessageCommands
 
                     #region DEBUG_COMMANDS
                     #if false
-                    case "item":
-                        Item item;
-                        item = new StardewValley.Object(StardewValley.Object.woodID, 1);
-                        item = new StardewValley.Object(StardewValley.Object.iridiumID, 100);
-                        Game1.player.addItemToInventory(item);
+
+                    case "iridium":
+                        Item itemi;
+                        itemi = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
+                        Game1.player.addItemToInventory(itemi);
+                        break;
+                    case "wood":
+
+                        Item itemw;
+                        itemw = new StardewValley.Object(StardewValley.Object.woodID, 999);
+                        Game1.player.addItemToInventory(itemw);
+                        break;
+
+                    case "stone":
+                        Item items;
+                        items = new StardewValley.Object(StardewValley.Object.stoneID, 999);
+                        Game1.player.addItemToInventory(items);
+                        break;
+
+                    case "hardwood":
+                        Item itemhw;
+                        itemhw = new StardewValley.Object(HardwoodItemId, 999);
+                        Game1.player.addItemToInventory(itemhw);
                         break;
 
                     case "emptyinventoryall": // /message serverbot EmptyInventoryAll
@@ -133,8 +155,6 @@ namespace DedicatedServer.MessageCommands
                     return;
                 }
             }      
-
-            string param = 1 < tokens.Length ? tokens[1].ToLower() : "";
 
             switch (command)
             {

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -268,7 +268,7 @@ namespace DedicatedServer.MessageCommands
         
         private void UpdateHouseLevel(Farmer farmer, string param)
         {
-            if (false == PasswordValidation.IsAuthorized(farmer.UniqueMultiplayerID, p => p.UpgradeHostHouseWithFarmhand))
+            if (false == PasswordValidation.IsAuthorized(farmer.UniqueMultiplayerID, p => p.UpgradeHouseLevelBasedOnFarmhand))
             {
                 WriteToPlayer(farmer, PasswordValidation.notAuthorizedMessage);
                 return;

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -175,7 +175,7 @@ namespace DedicatedServer.MessageCommands
                 {
                     return;
                 }
-            }      
+            }
 
             switch (command)
             {
@@ -265,7 +265,7 @@ namespace DedicatedServer.MessageCommands
             WriteToPlayer(null, $"Control has been transferred to the host, all host functions are switched on." + TextColor.Aqua);
             HostAutomation.Reset();
         }
-        
+
         private void UpdateHouseLevel(Farmer farmer, string param)
         {
             if (false == PasswordValidation.IsAuthorized(farmer.UniqueMultiplayerID, p => p.UpgradeHouseLevelBasedOnFarmhand))

--- a/DedicatedServer/Utils/HostHouseUpgrade.cs
+++ b/DedicatedServer/Utils/HostHouseUpgrade.cs
@@ -1,20 +1,17 @@
-﻿using StardewValley.Locations;
-using StardewValley;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Data;
-
+﻿using DedicatedServer.Chat;
+using DedicatedServer.Config;
 using Microsoft.Xna.Framework;
 using Netcode;
-
 using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Locations;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
-
-using DedicatedServer.Config;
-using DedicatedServer.Chat;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
 
 namespace DedicatedServer.Utils
 {
@@ -69,11 +66,13 @@ namespace DedicatedServer.Utils
         /// <summary>
         ///         Checks whether the host's house needs to be upgraded based on all players
         /// </summary>
-        public static void NeedsUpgrade()
+        public static bool NeedsUpgrade()
         {
+            bool upgradeIsBeingExecuted = false;
+
             if (IsHostUpgrading)
             {
-                return;
+                return true;
             }
             else
             {
@@ -101,6 +100,7 @@ namespace DedicatedServer.Utils
                 {
                     chatBox?.textBoxEnter($"The host will upgrade his house in {daysMin} days.");
                     DaysUntilHouseUpgrade(Game1.player, daysMin);
+                    upgradeIsBeingExecuted = true;
                 }
                 else
                 {
@@ -110,8 +110,10 @@ namespace DedicatedServer.Utils
                     {
                         chatBox?.textBoxEnter("The host will upgrade his house the next day.");
                         DaysUntilHouseUpgrade(Game1.player, 1);
+                        upgradeIsBeingExecuted = true;
                     }
                 }
+                return upgradeIsBeingExecuted;
             }
         }
 

--- a/DedicatedServer/Utils/HostHouseUpgrade.cs
+++ b/DedicatedServer/Utils/HostHouseUpgrade.cs
@@ -64,6 +64,33 @@ namespace DedicatedServer.Utils
         }
 
         /// <summary>
+        ///         Checks whether a cellar is available
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <returns>
+        ///         true:  Cellar is available
+        /// <br/>   false: There is no cellar
+        /// </returns>
+        public static bool HasCellar(Farmer farmer)
+        {
+            return farmer.craftingRecipes.Keys.Contains("Cask");
+        }
+
+        /// <summary>
+        ///         Checks whether a cellar is available
+        /// </summary>
+        /// <param name="location"></param>
+        /// <returns>
+        ///         true:  Cellar is available
+        /// <br/>   false: There is no cellar
+        /// </returns>
+        public static bool HasCellar(FarmHouse location)
+        {
+            return location.owner.craftingRecipes.Keys.Contains("Cask");
+            
+        }
+
+        /// <summary>
         ///         Checks whether the host's house needs to be upgraded based on all players
         /// </summary>
         public static bool NeedsUpgrade()
@@ -263,6 +290,8 @@ namespace DedicatedServer.Utils
         /// <br/>   - It is not safe to be in the house while the house is being upgraded or downgraded.
         /// <br/>   - Some items will be stored in a chest, but there are only 36 places to store items.
         /// <br/>   - All beds will be destroyed and a new bed will be set up.
+        /// <br/>   - The cellar is added to the map so that it cannot be removed.
+        /// <br/>     <see cref="StardewValley.Locations.FarmHouse.setMapForUpgradeLevel(int)"/>
         /// </summary>
         /// <param name="level">Target upgrade level of house</param>
         public static void ManualUpdate(string level)
@@ -303,6 +332,10 @@ namespace DedicatedServer.Utils
                 Game1.stats.checkForBuildingUpgradeAchievements();
                 Game1.player.performRenovation("FarmHouse");
 
+                if(2 == targetLevel && HasCellar(homeOfFarmer))
+                {
+                    chatBox?.textBoxEnter($"Can not remove cellar" + TextColor.Red);
+                }
 
                 AddBed(targetLevel, homeOfFarmer);
                 AddChestAndFillWithItems(items, targetLevel, homeOfFarmer);

--- a/DedicatedServer/Utils/HostHouseUpgrade.cs
+++ b/DedicatedServer/Utils/HostHouseUpgrade.cs
@@ -1,0 +1,336 @@
+﻿using StardewValley.Locations;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Data;
+
+using Microsoft.Xna.Framework;
+using Netcode;
+
+using StardewModdingAPI;
+using StardewValley.Objects;
+using StardewValley.TerrainFeatures;
+
+using DedicatedServer.Config;
+using DedicatedServer.Chat;
+
+namespace DedicatedServer.Utils
+{
+    internal class HostHouseUpgrade
+    {
+        private static string defaultBed = BedFurniture.DEFAULT_BED_INDEX;
+        private static string doubleBed = BedFurniture.DOUBLE_BED_INDEX;
+        private static string childBed = BedFurniture.CHILD_BED_INDEX;
+
+        private static FieldInfo farmerDaysUntilHouseUpgradeFieldInfo = typeof(Farmer).GetField("daysUntilHouseUpgrade");
+
+        private static IModHelper helper;
+        private static IMonitor monitor;
+        private static ModConfig config;
+        private static EventDrivenChatBox chatBox;
+
+        /// <summary>
+        ///         Checks whether the host is upgrading their home
+        /// </summary>
+        public static bool IsHostUpgrading { get { return DaysUntilHouseUpgrade(Game1.player) > -1; } }
+
+        public HostHouseUpgrade(IModHelper helper, IMonitor monitor, ModConfig config, EventDrivenChatBox chatBox)
+        {
+            HostHouseUpgrade.helper = helper;
+            HostHouseUpgrade.monitor = monitor;
+            HostHouseUpgrade.config = config;
+            HostHouseUpgrade.chatBox = chatBox;
+        }
+
+        /// <summary>
+        ///         Gets the days until the house is updated
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <returns></returns>
+        public static int DaysUntilHouseUpgrade(Farmer farmer)
+        {
+            return ((NetInt)(farmerDaysUntilHouseUpgradeFieldInfo.GetValue(farmer)))?.Value ?? -1;
+        }
+
+        /// <summary>
+        ///         Sets the days until the house is upgrades
+        /// <br/>   Values less than or equal to 0 deactivate the upgrade
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <param name="value">Number of days until the house is updated</param>
+        public static void DaysUntilHouseUpgrade(Farmer farmer, int value)
+        {
+            if(0 >= value) { value = -1; }
+            farmerDaysUntilHouseUpgradeFieldInfo.SetValue(Game1.player, new NetInt(value));
+        }
+
+        /// <summary>
+        ///         Checks whether the host's house needs to be upgraded based on all players
+        /// </summary>
+        public static void NeedsUpgrade()
+        {
+            if (IsHostUpgrading)
+            {
+                return;
+            }
+            else
+            {
+                int daysMin = int.MaxValue;
+                int levelMax = int.MinValue;
+
+                foreach (var farmer in Game1.getAllFarmhands().ToList())
+                {
+                    var localDays = DaysUntilHouseUpgrade(farmer);
+
+                    if(levelMax < farmer.HouseUpgradeLevel)
+                    {
+                        levelMax = farmer.HouseUpgradeLevel;
+                    }
+
+                    if (0 <= localDays && // -1 means that no update is performed
+                        localDays < daysMin && // select the lowest update days
+                        farmer.HouseUpgradeLevel >= Game1.player.HouseUpgradeLevel) // only update if the determined update leads to a higher house level
+                    {
+                        daysMin = localDays;
+                    }
+                }
+
+                if (daysMin != int.MaxValue && daysMin >= 0)
+                {
+                    chatBox?.textBoxEnter($"The host will upgrade his house in {daysMin} days.");
+                    DaysUntilHouseUpgrade(Game1.player, daysMin);
+                }
+                else
+                {
+                    // Manual (if ModConfig.UpgradeHostHouseWithFarmhand is deactivated) or
+                    // delayed upgrade (if ModConfig.UpgradeHostHouseWithFarmhand was deactivated)
+                    if (levelMax > Game1.player.HouseUpgradeLevel)
+                    {
+                        chatBox?.textBoxEnter("The host will upgrade his house the next day.");
+                        DaysUntilHouseUpgrade(Game1.player, 1);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///         Get all objects and removes them from the location. 
+        /// <br/>   - objects and furniture are treated
+        /// <br/>   - terrain features and large terrain features are not treated
+        /// <br/>   - all others not treated are deleted
+        /// </summary>
+        /// <param name="location">A location, default (null) is the host's FarmHouse.</param>
+        public static List<KeyValuePair<Vector2, StardewValley.Object>> GetAndRemoveAllItems(GameLocation location = null)
+        {
+            if(null == location)
+            {
+                location = Utility.getHomeOfFarmer(Game1.player);
+            }
+            
+            List<KeyValuePair<Vector2, StardewValley.Object>> items = new List<KeyValuePair<Vector2, StardewValley.Object>>();
+
+
+            List<KeyValuePair<Vector2, StardewValley.Object>> list1 = new List<KeyValuePair<Vector2, StardewValley.Object>>(location.Objects.Pairs);
+            location.Objects.Clear();
+            foreach (var item1 in list1)
+            {
+                if (null != item1.Value.lightSource)
+                {
+                    location.removeLightSource(item1.Value.lightSource.identifier);
+                }
+
+                if (item1.Value.GetType() == typeof(Chest))
+                {
+                    // The chest will not be added
+                    foreach (var chestItem in ((Chest)item1.Value).Items)
+                    {
+                        items.Add(new KeyValuePair<Vector2, StardewValley.Object>(Vector2.Zero, (StardewValley.Object)chestItem));
+                        item1.Value.performRemoveAction();
+                    }
+                }
+                else
+                {
+                    items.Add(item1);
+                    item1.Value.performRemoveAction();
+                }
+            }
+
+
+            List<KeyValuePair<Vector2, TerrainFeature>> list2 = new List<KeyValuePair<Vector2, TerrainFeature>>(location.terrainFeatures.Pairs);
+            location.terrainFeatures.Clear();
+            foreach (var item2 in list2)
+            {
+                // All items are currently being deleted
+            }
+
+
+            foreach (var largeTerrainFeature in location.largeTerrainFeatures)
+            {
+                // All items are currently being deleted
+            }
+
+
+            List<KeyValuePair<Vector2, Furniture>> list3 = location.furniture.Select(f => { return new KeyValuePair<Vector2, Furniture>(f.TileLocation, f); }).ToList();
+            location.furniture.Clear();
+            foreach (var item3 in list3)
+            {
+                item3.Value.removeLights();
+
+                if (item3.Value.GetType() != typeof(BedFurniture))
+                {
+                    items.Add(new KeyValuePair<Vector2, StardewValley.Object>(item3.Key, item3.Value));
+                }
+                item3.Value.performRemoveAction();
+
+            }
+            return items;
+        }
+
+        /// <summary>
+        ///         Adds the standard bed or beds depending on the upgrade level of the house
+        /// </summary>
+        /// <param name="upgradeLevel">Upgrade level of the house</param>
+        /// <param name="location"></param>
+        public static void AddBed(int upgradeLevel, GameLocation location = null)
+        {
+            if (null == location)
+            {
+                location = Utility.getHomeOfFarmer(Game1.player);
+            }
+
+            switch (upgradeLevel)
+            {
+                case 0:
+                    location.furniture.Add(new BedFurniture(defaultBed, new Vector2(9, 8)));
+                    break;
+                case 1:
+                    location.furniture.Add(new BedFurniture(doubleBed, new Vector2(21, 3)));
+                    break;
+                case 2:
+                case 3:
+                    location.furniture.Add(new BedFurniture(childBed, new Vector2(37, 14)));
+                    location.furniture.Add(new BedFurniture(childBed, new Vector2(41, 14)));
+                    location.furniture.Add(new BedFurniture(doubleBed, new Vector2(42, 22)));
+                    break;
+                default:
+                    location.furniture.Add(new BedFurniture(defaultBed, new Vector2(9, 8)));
+                    break;
+            }
+        }
+
+        /// <summary>
+        ///         Obtains a safe position for a chest, depending on the upgrade level of the house
+        /// </summary>
+        /// <param name="upgradeLevel">Upgrade level of the house</param>
+        /// <returns></returns>
+        private static Vector2 GetChestPosition(int upgradeLevel)
+        {
+            switch (upgradeLevel)
+            {
+                case 0: return new Vector2(3, 8);
+                case 1: return new Vector2(9, 7);
+                case 2:
+                case 3: return new Vector2(27, 27);
+                default: return Vector2.Zero;
+            }
+        }
+
+        public static void AddChestAndFillWithItems(List<Item> items, int upgradeLevel, GameLocation location = null)
+        {
+            if (null == location)
+            {
+                location = Utility.getHomeOfFarmer(Game1.player);
+            }
+
+            var chest = new Chest(true, GetChestPosition(upgradeLevel));
+
+            foreach (var item in items)
+            {
+                chest.addItem(item);
+            }
+
+            location.Objects.Add(chest.TileLocation, chest);
+        }
+
+        /// <summary>
+        ///         Upgrate and downgrade of the host's farme house.
+        /// <br/>   - Please remove all items, decorations and so on.
+        /// <br/>   - In case of doubt, everything will be deleted.
+        /// <br/>   - It is not safe to be in the house while the house is being upgraded or downgraded.
+        /// <br/>   - Some items will be stored in a chest, but there are only 36 places to store items.
+        /// <br/>   - All beds will be destroyed and a new bed will be set up.
+        /// </summary>
+        /// <param name="level">Target upgrade level of house</param>
+        public static void ManualUpdate(string level)
+        {
+            int targetLevel = -1;
+
+            if (IsHostUpgrading)
+            {
+                chatBox?.textBoxEnter($"An upgrade is being performed, wait until the update is complete.");
+                return;
+            }
+
+            try
+            {
+                targetLevel = Convert.ToInt16(level);
+            }
+            catch{}
+
+            int oldLevel = Game1.player.HouseUpgradeLevel;
+
+            if (oldLevel == targetLevel)
+            {
+                chatBox?.textBoxEnter($"The house has the level you want.");
+                return;
+            }
+
+            if( 0 <= targetLevel && 3 >= targetLevel)
+            {
+                FarmHouse homeOfFarmer = Utility.getHomeOfFarmer(Game1.player);
+
+                List<Item> items = GetAndRemoveAllItems(homeOfFarmer)
+                    .Select(list => list.Value)
+                    .ToList<Item>();
+
+
+                Game1.player.HouseUpgradeLevel = targetLevel;
+                homeOfFarmer.setMapForUpgradeLevel(targetLevel);
+                Game1.stats.checkForBuildingUpgradeAchievements();
+                Game1.player.performRenovation("FarmHouse");
+
+
+                AddBed(targetLevel, homeOfFarmer);
+                AddChestAndFillWithItems(items, targetLevel, homeOfFarmer);
+
+                DaysUntilHouseUpgrade(Game1.player, -1);
+            }
+        }
+        
+#if false
+        // Should not be used. Works but if a figure is inside the house,
+        // it can be placed outside the room boundaries when upgrading
+        public static void UpgradeToLevel(int targetLevel)
+        {
+            monitor.Log($"The host's farmhouse will upgraded to {targetLevel}", LogLevel.Debug);
+
+            // The house level is only increased by 1 every day
+            targetLevel = Game1.player.HouseUpgradeLevel + 1;
+
+            /// The following is based on class Farmer, methode dayupdate(int timeWentToSleep)
+            FarmHouse homeOfFarmer = Utility.getHomeOfFarmer(Game1.player);
+            homeOfFarmer.moveObjectsForHouseUpgrade((int)targetLevel);
+            Game1.player.HouseUpgradeLevel = targetLevel;
+            homeOfFarmer.setMapForUpgradeLevel(targetLevel);
+            Game1.stats.checkForBuildingUpgradeAchievements();
+            Game1.player.autoGenerateActiveDialogueEvent("houseUpgrade_" + targetLevel);
+
+            Game1.player.performRenovation("FarmHouse");
+
+            Game1.player.warpFarmer(WarpPoints.farmHouseWarp);
+        }
+#endif
+    }
+}

--- a/DedicatedServer/Utils/WarpPoints.cs
+++ b/DedicatedServer/Utils/WarpPoints.cs
@@ -17,6 +17,7 @@ namespace DedicatedServer.Utils
         private static Town townLocation = Game1.getLocationFromName("Town") as Town;
         private static Mine mineLocation = Game1.getLocationFromName("Mine") as Mine;
         private static Beach beachLocation = Game1.getLocationFromName("Beach") as Beach;
+        private static Mountain mountainLocation = Game1.getLocationFromName("Mountain") as Mountain;
 
         private static Point farmEntryLocation = farmLocation.GetMainFarmHouseEntry();
         private static Point farmHouseEntryLocation = farmHouseLocation.getEntryLocation();
@@ -79,9 +80,26 @@ namespace DedicatedServer.Utils
             beachEntryLocation.X, beachEntryLocation.Y,
             false, false);
 
+        /// <summary>
+        ///         Warp to Robin
+        /// </summary>
+        public static readonly Warp robinWarp = new Warp(
+            12, 26,
+            mountainLocation.NameOrUniqueName,
+            12, 26,
+            false, false);
+
+        /// <summary>
+        ///         Warp to Clint
+        /// </summary>
+        public static readonly Warp clintWarp = new Warp(
+            94, 82,
+            townLocation.NameOrUniqueName,
+            94, 82,
+            false, false);
+
         public static Warp Refresh(Farmer farmer)
         {
-
             return new Warp(
                 (int)farmer.Tile.X, (int)farmer.Tile.Y,
                 farmer.currentLocation.Name,

--- a/DedicatedServer/manifest.json
+++ b/DedicatedServer/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "DedicatedServer",
   "Author": "ObjectManagerManager",
-  "Version": "1.1.2",
+  "Version": "1.1.3",
   "Description": "Description",
   "UniqueID": "objectmanagermanager.DedicatedServer",
   "EntryDll": "DedicatedServer.dll",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Upon running SMAPI with the mod installed for the first time, a `config.json` fi
 - `MoveBuildPermission`: Change farmhands permissions to move buildings from the Carpenter's shop. Is set each time the server is started and can be changed in the game. Set to `off` to entirely disable moving buildings, set to `owned` to allow farmhands to move buildings that they purchased, or set to `on` to allow moving all buildings.
 - `Password`: Password used to log in. It must be changed to a secure password. An empty string `""` means no password. Any check fails if the value is set to `null`.
 - `PasswordProtected`: The password protection of individual functions can be switched on (`true`) and off (`false`) in the group.
+- `UpgradeHouseLevelBasedOnFarmhand`: Set this value to `true` or `false` to activate the automatic upgrade of the host farmhouse according to the highest farmhouse level of a player.
 
 ## In Game Command
 
@@ -52,6 +53,17 @@ All commands in the game must be sent privately to the player `ServerBot`. For e
 - `Pause`: (Toggle command) \
   Pause the game
 - `TakeOver`: The host player returns control to the host, all host functions are switched on. Cancels the [`LetMePlay`](#host-in-game-command) command
+- `UpdateHouseLevel`: Can be used with and without a parameter.
+  - Without a parameter:
+    - The command triggers the check function and the host farmhouse is upgraded to the next level if another farmer has a farmhouse with a higher farmhouse level than the host.
+    - The additional options entry `UpgradeHouseLevelBasedOnFarmhand` is ignored.
+  - With a parameter from 0 to 3:
+    - The host farmhouse will be upgraded immediately, please note:
+      - It is not safe to be in the farmhouse while the farmhouse is being upgraded or downgraded.
+      - Please remove all items, decorations and so on.
+      - Some items will be stored in a chest, but there are only 36 places to store items.
+      - Everything else will be deleted.  
+      - All beds will be destroyed and a new bed will be set up.
 - `SafeInviteCode`: A file `invite_code.txt` with the invitation code is created in this mods folder. If there is no invitation code, an empty string is saved.
 - `InviteCode`: The invitation code is printed.
 - `ForceInviteCode`: Forces the invitation code by closing and reopening the multiplayer server. There is an 8 second warning before the server stops, after another 2 seconds it is restarted.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ All commands in the game must be sent privately to the player `ServerBot`. For e
       - Some items will be stored in a chest, but there are only 36 places to store items.
       - Everything else will be deleted.  
       - All beds will be destroyed and a new bed will be set up.
+      - The cellar cannot be removed.
 - `SafeInviteCode`: A file `invite_code.txt` with the invitation code is created in this mods folder. If there is no invitation code, an empty string is saved.
 - `InviteCode`: The invitation code is printed.
 - `ForceInviteCode`: Forces the invitation code by closing and reopening the multiplayer server. There is an 8 second warning before the server stops, after another 2 seconds it is restarted.


### PR DESCRIPTION
The reason for this branch was that when a house was upgraded, the host always upgraded his house. There were problems with the position of the host's bed and only the host can move the bed. Now the bed is placed correctly and you can decide whether the host should upgrade at all.

- Server command `UpdateHouseLevel` added.
  - Without a parameter:
    - The command triggers the check function and the host farmhouse is upgraded to the next level if another farmer has a farmhouse with a higher farmhouse level than the host.
    - The additional options entry UpgradeHouseLevelBasedOnFarmhand is ignored.
  - With a parameter from 0 to 3:
    - The host farmhouse will be upgraded immediately, please note:
    - It is not safe to be in the farmhouse while the farmhouse is being upgraded or downgraded.
    - Please remove all items, decorations and so on.
    - Some items will be stored in a chest, but there are only 36 places to store items.
    - Everything else will be deleted.
    - All beds will be destroyed and a new bed will be set up.
- Added server configuration `UpgradeHouseLevelBasedOnFarmhand` to activate the automatic upgrade of the host farmhouse according to the highest farmhouse level of a player.
