### PR TITLE
Fixed problem with the MoveBuildPermission

### DIFF
--- a/DedicatedServer/HostAutomatorStages/StartFarmStage.cs
+++ b/DedicatedServer/HostAutomatorStages/StartFarmStage.cs
@@ -295,8 +295,6 @@ namespace DedicatedServer.HostAutomatorStages
                 Game1.player.isCustomized.Value = true;
                 Game1.multiplayerMode = 2;
 
-                MoveBuildPermission.Change(config.MoveBuildPermission);
-
                 // Start game
                 menu.createdNewCharacter(true);
             }
@@ -353,11 +351,7 @@ namespace DedicatedServer.HostAutomatorStages
             sleepWorker = new SleepWorker(helper);
             restartDayWorker = new RestartDayWorker(helper);
             multiplayerOptions = new MultiplayerOptions(helper, config, chatBox);
-            if (config.TryActivatingInviteCode)
-            {
-                MultiplayerOptions.TryActivatingInviteCode();
-            }
-            moveBuildPermission = new MoveBuildPermission(chatBox);
+            moveBuildPermission = new MoveBuildPermission(monitor, config, chatBox);
             hostHouseUpgrade = new HostHouseUpgrade(helper, monitor, config, chatBox);
             wallet = new Wallet(chatBox);
 

--- a/DedicatedServer/Utils/MoveBuildPermission.cs
+++ b/DedicatedServer/Utils/MoveBuildPermission.cs
@@ -1,4 +1,6 @@
 ﻿using DedicatedServer.Chat;
+using DedicatedServer.Config;
+using StardewModdingAPI;
 using StardewValley;
 using System.Collections.Generic;
 using static StardewValley.FarmerTeam;
@@ -7,6 +9,8 @@ namespace DedicatedServer.Utils
 {
     internal class MoveBuildPermission
     {
+        private static IMonitor monitor = null;
+        private static ModConfig config = null;
         private static EventDrivenChatBox chatBox = null;
 
         private static readonly string moveBuildPermission =
@@ -28,9 +32,13 @@ namespace DedicatedServer.Utils
             set => Game1.player.team.farmhandsCanMoveBuildings.Value = value;
         }
 
-        public MoveBuildPermission(EventDrivenChatBox chatBox)
+        public MoveBuildPermission(IMonitor monitor, ModConfig config, EventDrivenChatBox chatBox)
         {
+            MoveBuildPermission.monitor = monitor;
+            MoveBuildPermission.config = config;
             MoveBuildPermission.chatBox = chatBox;
+
+            MoveBuildPermission.Change(config.MoveBuildPermission);
         }
 
         /// <summary>
@@ -48,13 +56,16 @@ namespace DedicatedServer.Utils
             {
                 case "on":
                     buildPermission = RemoteBuildingPermissions.On;
+                    monitor?.Log($"Changed move permission to {RemoteBuildingPermissions.On}", LogLevel.Debug);
                     break;
                 case "owned":
                 case "ownedbuildings":
                     buildPermission = RemoteBuildingPermissions.OwnedBuildings;
+                    monitor?.Log($"Changed move permission to {RemoteBuildingPermissions.OwnedBuildings}", LogLevel.Debug);
                     break;
                 default:
                     buildPermission = RemoteBuildingPermissions.Off;
+                    monitor?.Log($"Changed move permission to {RemoteBuildingPermissions.Off}", LogLevel.Debug);
                     break;
             }
 

--- a/DedicatedServer/Utils/MultiplayerOptions.cs
+++ b/DedicatedServer/Utils/MultiplayerOptions.cs
@@ -65,6 +65,11 @@ namespace DedicatedServer.Utils
             MultiplayerOptions.helper = helper;
             MultiplayerOptions.config = config;
             MultiplayerOptions.chatBox = chatBox;
+
+            if (config.TryActivatingInviteCode)
+            {
+                TryActivatingInviteCode();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed problem with the move buildings permission

- Now the config value `MoveBuildPermission` is set when the server is started.
- SMAPI debug output added.