### PR TITLE
Fixed the warp problem

### DIFF
--- a/DedicatedServer/HostAutomatorStages/EndCommunityCenterBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/EndCommunityCenterBehaviorLink.cs
@@ -20,7 +20,7 @@ namespace DedicatedServer.HostAutomatorStages
                 isEnding = true;
             }
             else if (isEnding && Game1.player.eventsSeen.Contains("191393")) {
-                Game1.player.warpFarmer(WarpPoints.farmWarp);
+                Game1.player.warpFarmer(WarpPoints.FarmWarp);
                 isEnding = false;
             }
             else

--- a/DedicatedServer/HostAutomatorStages/ExitFarmHouseBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/ExitFarmHouseBehaviorLink.cs
@@ -27,7 +27,7 @@ namespace DedicatedServer.HostAutomatorStages
                 Game1.timeOfDay < TimeToEnterFarmhouse && 
                 Game1.currentLocation != null && Game1.currentLocation is FarmHouse)
             {
-                Game1.player.warpFarmer(WarpPoints.farmWarp);
+                Game1.player.warpFarmer(WarpPoints.FarmWarp);
                 state.ExitFarmhouse(); // Mark as exited
                 state.SetWaitTicks(60); // Set up wait ticks to wait for possible event
             }
@@ -38,7 +38,7 @@ namespace DedicatedServer.HostAutomatorStages
                     Game1.currentLocation != null && Game1.currentLocation is Farm &&
                     true == Game1.spawnMonstersAtNight)
                 {
-                    Game1.player.warpFarmer(WarpPoints.farmHouseWarp);
+                    Game1.player.warpFarmer(WarpPoints.FarmHouseWarp);
                     state.EnteredFarmhouse();
                     state.SetWaitTicks(60);
                 }

--- a/DedicatedServer/HostAutomatorStages/GetFishingRodBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/GetFishingRodBehaviorLink.cs
@@ -21,7 +21,7 @@ namespace DedicatedServer.HostAutomatorStages
                 isGettingFishingRod = true;
             }
             else if (isGettingFishingRod && Game1.player.eventsSeen.Contains("739330")) {
-                Game1.player.warpFarmer(WarpPoints.farmWarp);
+                Game1.player.warpFarmer(WarpPoints.FarmWarp);
                 isGettingFishingRod = false;
             }
             else

--- a/DedicatedServer/HostAutomatorStages/RestartDayWorker.cs
+++ b/DedicatedServer/HostAutomatorStages/RestartDayWorker.cs
@@ -100,7 +100,7 @@ namespace DedicatedServer.HostAutomatorStages
                 Game1.server.kick(farmer.UniqueMultiplayerID);
             }
 
-            Game1.player.warpFarmer(WarpPoints.farmHouseWarp);
+            Game1.player.warpFarmer(WarpPoints.FarmHouseWarp);
 
             Game1.player.isInBed.Value = true;
             Game1.currentLocation.answerDialogueAction("Sleep_Yes", null);

--- a/DedicatedServer/HostAutomatorStages/TransitionSleepBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/TransitionSleepBehaviorLink.cs
@@ -67,7 +67,7 @@ namespace DedicatedServer.HostAutomatorStages
                 else
                 {
                     monitor.Log($"Warp to sleep", LogLevel.Debug);
-                    Game1.player.warpFarmer(WarpPoints.farmHouseWarp);
+                    Game1.player.warpFarmer(WarpPoints.FarmHouseWarp);
                     state.WarpToSleep();
                 }
             }

--- a/DedicatedServer/HostAutomatorStages/UnlockCommunityCenterBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/UnlockCommunityCenterBehaviorLink.cs
@@ -20,7 +20,7 @@ namespace DedicatedServer.HostAutomatorStages
                 isUnlocking = true;
             }
             else if (isUnlocking && Game1.player.eventsSeen.Contains("611439")) {
-                Game1.player.warpFarmer(WarpPoints.farmWarp);
+                Game1.player.warpFarmer(WarpPoints.FarmWarp);
                 isUnlocking = false;
             }
             else

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -63,7 +63,14 @@ namespace DedicatedServer.MessageCommands
                         break;
 
                     #region DEBUG_COMMANDS
-                    #if false
+#if true
+
+                    case "w1":
+                        Game1.player.warpFarmer(WarpPoints.FarmHouseWarp);
+                        break;
+                    case "w2":
+                        Game1.player.warpFarmer(WarpPoints.FarmWarp);
+                        break;
 
                     case "items":
                         Item item;
@@ -132,11 +139,11 @@ namespace DedicatedServer.MessageCommands
                         break;
 
                     case "farm":
-                        Game1.player.warpFarmer(WarpPoints.farmWarp);
+                        Game1.player.warpFarmer(WarpPoints.FarmWarp);
                         break;
 
                     case "house":
-                        Game1.player.warpFarmer(WarpPoints.farmHouseWarp);
+                        Game1.player.warpFarmer(WarpPoints.FarmHouseWarp);
                         break;
 
                     case "mine":

--- a/DedicatedServer/Utils/WarpPoints.cs
+++ b/DedicatedServer/Utils/WarpPoints.cs
@@ -7,23 +7,27 @@ using System.Threading.Tasks;
 
 using Microsoft.Xna.Framework;
 using StardewValley.Locations;
+using xTile.Dimensions;
 
 namespace DedicatedServer.Utils
 {
     internal abstract class WarpPoints
     {
-        private static Farm farmLocation = Game1.getLocationFromName("Farm") as Farm;
-        private static FarmHouse farmHouseLocation = Game1.getLocationFromName("FarmHouse") as FarmHouse;
-        private static Town townLocation = Game1.getLocationFromName("Town") as Town;
-        private static Mine mineLocation = Game1.getLocationFromName("Mine") as Mine;
-        private static Beach beachLocation = Game1.getLocationFromName("Beach") as Beach;
-        private static Mountain mountainLocation = Game1.getLocationFromName("Mountain") as Mountain;
+        private static readonly Farm farmLocation = Game1.getLocationFromName("Farm") as Farm;
+        private static readonly FarmHouse farmHouseLocation = Game1.getLocationFromName("FarmHouse") as FarmHouse;
+        private static readonly Town townLocation = Game1.getLocationFromName("Town") as Town;
+        private static readonly Mine mineLocation = Game1.getLocationFromName("Mine") as Mine;
+        private static readonly Beach beachLocation = Game1.getLocationFromName("Beach") as Beach;
+        private static readonly Mountain mountainLocation = Game1.getLocationFromName("Mountain") as Mountain;
 
-        private static Point farmEntryLocation = farmLocation.GetMainFarmHouseEntry();
-        private static Point farmHouseEntryLocation = farmHouseLocation.getEntryLocation();
-        private static Point townNorthWestEntryLocation = new Point(0, 54);
-        private static Point mineEntryLocation = new Point(18, 13);
-        private static Point beachEntryLocation = new Point(38, 0);
+        private static Point FarmEntryLocation => farmLocation.GetMainFarmHouseEntry();
+        private static Point FarmHouseEntryLocation => farmHouseLocation.getEntryLocation();
+
+        private static readonly Point townNorthWestEntryLocation = new Point(0, 54);
+        private static readonly Point mineEntryLocation = new Point(18, 13);
+        private static readonly Point beachEntryLocation = new Point(38, 0);
+        private static readonly Point robinLocation = new Point(12, 26);
+        private static readonly Point clintLocation = new Point(94, 82);
 
         /// <summary>
         ///         Warppoint on the farm
@@ -31,26 +35,36 @@ namespace DedicatedServer.Utils
         /// <br/>   As the host is invisible and cannot be interacted with, the position
         /// <br/>   does not matter. A visible position simply allows you to interact with
         /// <br/>   the host when it has been made visible again with the `Invisible` command.
-        /// <br/>   +2 places the host on the veranda on the right
-        /// <br/>
-        /// <br/>   Warping to 64, 10 warps just behind the farmhouse. It "hides" the bot,
-        /// <br/>   but still allows him to perform actions like talking to npcs.
-        /// <br/>   64, 15 coords are "magic numbers" pulled from Game1.cs, line 11282, warpFarmer()
+        /// <br/>   +2 places the host on the veranda on the right.
         /// </summary>
-        public static readonly Warp farmWarp = new Warp(
-            farmEntryLocation.X + 2, farmEntryLocation.Y,
-            farmLocation.NameOrUniqueName,
-            farmEntryLocation.X + 2, farmEntryLocation.Y,
-            false, false);
+        public static Warp FarmWarp
+        {
+            get
+            {
+                var location = FarmEntryLocation;
+                return new Warp(
+                    location.X + 2, location.Y,
+                    farmLocation.NameOrUniqueName,
+                    location.X + 2, location.Y,
+                    false, false);
+            }
+        }
 
         /// <summary>
         ///         Warppoint into the farmhouse
         /// </summary>
-        public static readonly Warp farmHouseWarp = new Warp(
-            farmHouseEntryLocation.X, farmHouseEntryLocation.Y,
-            farmHouseLocation.NameOrUniqueName,
-            farmHouseEntryLocation.X, farmHouseEntryLocation.Y,
-            false, false);
+        public static Warp FarmHouseWarp
+        {
+            get
+            {
+                var location = FarmHouseEntryLocation;
+                return new Warp(
+                    location.X, location.Y,
+                    farmHouseLocation.NameOrUniqueName,
+                    location.X, location.Y,
+                    false, false);
+            }
+        }
 
         /// <summary>
         ///         Warppoint to town, northwest entrance
@@ -84,18 +98,18 @@ namespace DedicatedServer.Utils
         ///         Warp to Robin
         /// </summary>
         public static readonly Warp robinWarp = new Warp(
-            12, 26,
+            robinLocation.X, robinLocation.Y,
             mountainLocation.NameOrUniqueName,
-            12, 26,
+            robinLocation.X, robinLocation.Y,
             false, false);
 
         /// <summary>
         ///         Warp to Clint
         /// </summary>
         public static readonly Warp clintWarp = new Warp(
-            94, 82,
+            clintLocation.X, clintLocation.Y,
             townLocation.NameOrUniqueName,
-            94, 82,
+            clintLocation.X, clintLocation.Y,
             false, false);
 
         public static Warp Refresh(Farmer farmer)


### PR DESCRIPTION
- Warping now also works after upgrading, downgrading or moving the farmhouse.
- The `farmWarp` variable has been changed to the `FarmWarp` property.
- The `FarmWarp` property now retains the current position of the farmhouse, even after moving the building.
- The `farmHouseWarp` variable has been changed to the `FarmHouseWarp` property.
- The `FarmHouseWarp` property now receives the actual position of the entrance, even after an upgrade or downgrade of the farmhouse.
- A location variable has been added for Robin and Clint.