### PR TITLE
Task find problems with crop saver

### DIFF
--- a/DedicatedServer/Crops/CropSaver.cs
+++ b/DedicatedServer/Crops/CropSaver.cs
@@ -108,6 +108,15 @@ namespace DedicatedServer.Crops
             {
                 fstream?.Close();
             }
+
+            foreach(var pair in cropDictionary)
+            {
+                string id = pair.Value.HarvestItemId;
+                if(false == harvestItemIdSeasonDictionary.ContainsKey(id))
+                {
+                    harvestItemIdSeasonDictionary.Add(id, pair.Value.OriginalSeasonsToGrowIn);
+                }
+            }
         }
 
         private void onSaving(object sender, StardewModdingAPI.Events.SavingEventArgs e)
@@ -327,6 +336,7 @@ namespace DedicatedServer.Crops
                                     else
                                     {
                                         seasons = new List<Season>(crop.GetData().Seasons);
+                                        harvestItemIdSeasonDictionary.Add(id, seasons);
                                     }
 
                                     var cd = new CropData
@@ -492,7 +502,7 @@ namespace DedicatedServer.Crops
 
                                 // Lastly, now that the crop has been updated, construct the comparison data for later
                                 // so that we can check if this has been replaced by a newly planted crop in the evening.
-
+                                
                                 var cropGrowthStage = new CropGrowthStage
                                 {
                                     CurrentPhase = crop.currentPhase.Value,

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -23,8 +23,9 @@ namespace DedicatedServer.MessageCommands
 
         private const string hardwoodItemId = "709";
         private const string iridiumSprinkler = "645";
-        private const string greenBean = "188";
-        //private const string beanStarter = "473";
+        private const string beanStarter = "473";
+        private const string pepperSeed = "482";
+        private const string eggplantSeeds = "488";
 
         public ServerCommandListener(IModHelper helper, ModConfig config, EventDrivenChatBox chatBox)
         {
@@ -126,7 +127,7 @@ namespace DedicatedServer.MessageCommands
                     case "inventory":
                         foreach(var inventoryItems in Game1.player.Items)
                         {
-                            var itemId = inventoryItems.ItemId;
+                            var itemId = inventoryItems?.ItemId;
                         }
                         break;
 

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -3,6 +3,7 @@ using DedicatedServer.Config;
 using DedicatedServer.HostAutomatorStages;
 using DedicatedServer.Utils;
 using StardewModdingAPI;
+using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Locations;
 using StardewValley.Menus;
@@ -20,7 +21,10 @@ namespace DedicatedServer.MessageCommands
 
         private IModHelper helper;
 
-        private const string HardwoodItemId = "709";
+        private const string hardwoodItemId = "709";
+        private const string iridiumSprinkler = "645";
+        private const string greenBean = "188";
+        //private const string beanStarter = "473";
 
         public ServerCommandListener(IModHelper helper, ModConfig config, EventDrivenChatBox chatBox)
         {
@@ -38,6 +42,45 @@ namespace DedicatedServer.MessageCommands
         {
             chatBox.ChatReceived -= chatReceived;
         }
+
+        #region DEBUG_SKIP_DAYS
+        #if true
+
+        // Each day is run so that all events are executed normally.
+
+        private int dayOfMonth = -1;
+        private Season season;
+        private void EnableSkipDays(int dayOfMonth, Season season)
+        {
+            this.dayOfMonth = dayOfMonth;
+            this.season = season;
+            helper.Events.GameLoop.OneSecondUpdateTicked += SkipDays;
+            SkipDays(null, null);
+        }
+
+        private void DisableSkipDays()
+        {
+            this.dayOfMonth = -1;
+            helper.Events.GameLoop.OneSecondUpdateTicked -= SkipDays;
+            Sleeping.ShouldSleepOverwrite = false;
+        }
+
+        private void SkipDays(object sender, OneSecondUpdateTickedEventArgs e)
+        {
+            if (dayOfMonth > Game1.dayOfMonth || Game1.season != this.season)
+            {
+                if(false == Sleeping.ShouldSleepOverwrite)
+                {
+                    Sleeping.ShouldSleepOverwrite = true;
+                }
+            }
+            else
+            {
+                DisableSkipDays();
+            }
+        }
+        #endif
+        #endregion
 
         private void chatReceived(object sender, ChatEventArgs e)
         {
@@ -65,56 +108,54 @@ namespace DedicatedServer.MessageCommands
                     #region DEBUG_COMMANDS
 #if true
 
-                    case "w1":
-                        Game1.player.warpFarmer(WarpPoints.FarmHouseWarp);
-                        break;
-                    case "w2":
-                        Game1.player.warpFarmer(WarpPoints.FarmWarp);
+                    case "skipdays":
+                        EnableSkipDays(15, Season.Spring);
                         break;
 
-                    case "items":
-                        Item item;
-                        item = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
-                        Game1.player.addItemToInventory(item);
-                        item = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
-                        Game1.player.addItemToInventory(item);
-                        item = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
-                        Game1.player.addItemToInventory(item);
-                        item = new StardewValley.Object(StardewValley.Object.woodID, 999);
-                        Game1.player.addItemToInventory(item);
-                        item = new StardewValley.Object(StardewValley.Object.stoneID, 999);
-                        Game1.player.addItemToInventory(item);
+                    case "item":
+                        if ("" != param)
+                        {
+                            int param2 = Convert.ToInt16(2 < tokens.Length ? tokens[2].ToLower() : "-1");
+                            if (0 <= param2)
+                            {
+                                Game1.player.addItemToInventory(new StardewValley.Object(param, param2));
+                            }
+                        }
                         break;
 
                     case "inventory":
                         foreach(var inventoryItems in Game1.player.Items)
                         {
-                            ;
+                            var itemId = inventoryItems.ItemId;
                         }
                         break;
 
+                    case "items":
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.iridiumID, 999));
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.iridiumID, 999));
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.iridiumID, 999));
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.woodID, 999));
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.stoneID, 999));
+                        break;
+
+                    case "iridiumsprinkler":
+                        Game1.player.addItemToInventory(new StardewValley.Object(iridiumSprinkler, 10));
+                        break;
+
                     case "iridium":
-                        Item itemi;
-                        itemi = new StardewValley.Object(StardewValley.Object.iridiumID, 999);
-                        Game1.player.addItemToInventory(itemi);
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.iridiumID, 999));
                         break;
 
                     case "wood":
-                        Item itemw;
-                        itemw = new StardewValley.Object(StardewValley.Object.woodID, 999);
-                        Game1.player.addItemToInventory(itemw);
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.woodID, 999));
                         break;
 
                     case "stone":
-                        Item items;
-                        items = new StardewValley.Object(StardewValley.Object.stoneID, 999);
-                        Game1.player.addItemToInventory(items);
+                        Game1.player.addItemToInventory(new StardewValley.Object(StardewValley.Object.stoneID, 999));
                         break;
 
                     case "hardwood":
-                        Item itemhw;
-                        itemhw = new StardewValley.Object(HardwoodItemId, 999);
-                        Game1.player.addItemToInventory(itemhw);
+                        Game1.player.addItemToInventory(new StardewValley.Object(hardwoodItemId, 999));
                         break;
 
                     case "emptyinventoryall": // /message serverbot EmptyInventoryAll
@@ -164,6 +205,10 @@ namespace DedicatedServer.MessageCommands
 
                     case "clint":
                         Game1.player.warpFarmer(WarpPoints.clintWarp);
+                        break;
+
+                    case "pierre":
+                        Game1.player.warpFarmer(WarpPoints.pierreWarp);
                         break;
 
                     case "location":

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -110,13 +110,13 @@ namespace DedicatedServer.MessageCommands
 #if true
 
                     case "skipdays":
-                        EnableSkipDays(15, Season.Spring);
+                        EnableSkipDays(28, Season.Spring);
                         break;
 
                     case "item":
                         if ("" != param)
                         {
-                            int param2 = Convert.ToInt16(2 < tokens.Length ? tokens[2].ToLower() : "-1");
+                            int param2 = int.TryParse(2 < tokens.Length ? tokens[2] : "1", out int param2try) ? param2try : 1;
                             if (0 <= param2)
                             {
                                 Game1.player.addItemToInventory(new StardewValley.Object(param, param2));

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -107,10 +107,10 @@ namespace DedicatedServer.MessageCommands
                         break;
 
                     #region DEBUG_COMMANDS
-#if true
+                    #if false
 
                     case "skipdays":
-                        EnableSkipDays(28, Season.Spring);
+                        EnableSkipDays(28, Season.Fall);
                         break;
 
                     case "item":

--- a/DedicatedServer/Utils/WarpPoints.cs
+++ b/DedicatedServer/Utils/WarpPoints.cs
@@ -28,6 +28,7 @@ namespace DedicatedServer.Utils
         private static readonly Point beachEntryLocation = new Point(38, 0);
         private static readonly Point robinLocation = new Point(12, 26);
         private static readonly Point clintLocation = new Point(94, 82);
+        private static readonly Point pierreLocation = new Point(43, 57);
 
         /// <summary>
         ///         Warppoint on the farm
@@ -110,6 +111,15 @@ namespace DedicatedServer.Utils
             clintLocation.X, clintLocation.Y,
             townLocation.NameOrUniqueName,
             clintLocation.X, clintLocation.Y,
+            false, false);
+
+        /// <summary>
+        ///         Warp to Pierre
+        /// </summary>
+        public static readonly Warp pierreWarp = new Warp(
+            pierreLocation.X, pierreLocation.Y,
+            townLocation.NameOrUniqueName,
+            pierreLocation.X, pierreLocation.Y,
             false, false);
 
         public static Warp Refresh(Farmer farmer)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # SMAPI Dedicated Server Mod for Stardew Valley
 
-<p align="center">
-  <img src="https://img.shields.io/badge/Version-1.6.8-blue" />
-</p>
+<div align="center">
+
+  [![Stardew Valley 1.6.8](https://img.shields.io/badge/Stardew_Valley-1.6.8-153C86)](https://www.stardewvalley.net/ "Link to Stardew Valley")
+  [![SMAPI 4.0.8](https://img.shields.io/badge/SMAPI-4.0.8-5cb811)](https://smapi.io/ "Link to SMAPI")
+  [![Docker Version](https://img.shields.io/badge/Docker_Version-_-2496ED)](https://github.com/Chris82111/StardewValleyViaDocker "Link to StardewValleyViaDocker ")
+
+</div>
 
 This mod provides a dedicated (headless) server for Stardew Valley, powered by SMAPI. It turns the host farmer into an automated bot to facilitate multiplayer gameplay.
 
@@ -38,7 +42,7 @@ Upon running SMAPI with the mod installed for the first time, a `config.json` fi
 
 ### Additional Options
 
-- `EnableCropSaver`: Set to `true` or `false` to enable or disable the crop saver feature. When enabled, seasonal crops planted by players and fully grown before the season's end are guaranteed to give at least one more harvest before dying. For example, a spring crop planted by a player and fully grown before Summer 1 will not die immediately on Summer 1. Instead, it'll provide exactly one more harvest, even if it's a crop that ordinarily produces multiple harvests. Defaults to `true`.
+- `EnableCropSaver`: Set to `true` or `false` to enable or disable the crop saver feature. When enabled, seasonal crops planted by players and fully grown before the season's end are guaranteed to give at least one more harvest before dying. For example, a spring crop planted by a player and fully grown before Summer 1 will not die immediately on Summer 1. Instead, it'll provide exactly one more harvest, even if it's a crop that ordinarily produces multiple harvests. You must remember that once a seed of a variety has been sown, it can be sown the next day at any time of the year. But if it is not the original season, it will die the next day. You can lose a lot of seeds. As soon as the last plant of a species has been destroyed (dried plants count), the seed can only be sown in its original season from the next day onwards. Defaults to `true`.
 - `MoveBuildPermission`: Change farmhands permissions to move buildings from the Carpenter's shop. Is set each time the server is started and can be changed in the game. Set to `off` to entirely disable moving buildings, set to `owned` to allow farmhands to move buildings that they purchased, or set to `on` to allow moving all buildings.
 - `Password`: Password used to log in. It must be changed to a secure password. An empty string `""` means no password. Any check fails if the value is set to `null`.
 - `PasswordProtected`: The password protection of individual functions can be switched on (`true`) and off (`false`) in the group.


### PR DESCRIPTION
Fixed bug, plants are now destroyed in the wrong seasons during harvesting

- Only harvestable plants survive the changing seasons.
- All plants can then be harvested once.
- Once a seed of one type has been sown, it can be sown the next day at any time of the year.
- As soon as the last plant of a species has been destroyed (dried plants count), the seed can only be sown in its original season from the next day onwards.