### PR TITLE
Task start events automatically

### DIFF
--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -1,5 +1,6 @@
 ﻿using DedicatedServer.HostAutomatorStages.BehaviorStates;
 using DedicatedServer.Utils;
+using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
 using System;
@@ -7,6 +8,28 @@ using System.Reflection;
 
 namespace DedicatedServer.HostAutomatorStages
 {
+    enum TransitionFestival
+    {
+        Uninit = 0, // default value and set at each end of the day
+
+        NoFestivalDay, // set after the day is started
+        FestivalDay, // set after the day is started
+
+        FestivalNotStarted,
+        FestivalGoingOn,
+        FestivalIsOver,
+
+        SomeoneWantsToGoTheFestival,
+
+        StartingFestival,
+
+        AtFestivalChatBox,
+        AtFestival,
+
+        SomeoneWantsToLeaveTheFestival,
+        EndingFestival,
+    }
+
     internal class TransitionFestivalAttendanceBehaviorLink : BehaviorLink
     {
         #region Required in derived class
@@ -16,39 +39,108 @@ namespace DedicatedServer.HostAutomatorStages
 
         public override void Process()
         {
-            var numberOfPlayers = MainController.NumberOfPlayers;
+            bool isEvent = null != Game1.CurrentEvent;
+            
+            int ready;
+            int required;
+            switch (TransitionFestival)
+            {
+                case TransitionFestival.Uninit:
+                    ;
+                    break;
 
-            if (Festivals.ShouldAttend(numberOfPlayers) && 
-                false == Festivals.IsWaitingToAttend())
-            {
-                WaitForFestivalAttendance();
-            }
-            else if (
-                false == Festivals.ShouldAttend(numberOfPlayers) && 
-                Festivals.IsWaitingToAttend())
-            {
-                StopWaitingForFestivalAttendance();
-            }
-            else if(Festivals.ShouldLeave(numberOfPlayers) &&
-                false == Festivals.IsWaitingToLeave())
-            {
-                WaitForFestivalEnd();
-            }
-            else if (
-                false == Festivals.ShouldLeave(numberOfPlayers) &&
-                Festivals.IsWaitingToLeave())
-            {
-                StopWaitingForFestivalEnd();
-            }
-            else
-            {
-                Tuple<int, int> voteCounts = UpdateFestivalStartVotes();
-                if (voteCounts != null)
-                {
-                    if (voteCounts.Item1 == voteCounts.Item2)
+
+                case TransitionFestival.NoFestivalDay:
+                    ;
+                    break;
+
+
+                case TransitionFestival.FestivalDay:
+                    if (Festivals.IsTheFestivalGoingOn())
                     {
-                        // Start the festival
-                        SendChatMessage($"{voteCounts.Item1} / {voteCounts.Item2} votes casted. Starting the festival event...");
+                        TransitionFestival = TransitionFestival.FestivalGoingOn;
+                        break;
+                    }
+                    break;
+
+
+                case TransitionFestival.FestivalGoingOn:
+                    if (false == Festivals.IsTheFestivalGoingOn())
+                    {
+                        TransitionFestival = TransitionFestival.FestivalIsOver;
+                        break;
+                    }
+
+                    ready = Game1.netReady.GetNumberReady("festivalStart");
+                    if (0 < ready)
+                    {
+                        TransitionFestival = TransitionFestival.SomeoneWantsToGoTheFestival;
+                        WaitForFestivalAttendance();
+                        break;
+                    }
+                    break;
+
+
+                case TransitionFestival.SomeoneWantsToGoTheFestival:
+                    if (false == Festivals.IsTheFestivalGoingOn())
+                    {
+                        TransitionFestival = TransitionFestival.FestivalIsOver;
+                        break;
+                    }
+
+                    ready = Game1.netReady.GetNumberReady("festivalStart");
+                    if (1>= ready)
+                    {
+                        TransitionFestival = TransitionFestival.FestivalGoingOn;
+                        StopWaitingForFestivalAttendance();
+                        break;
+                    }
+
+                    required = Game1.netReady.GetNumberRequired("festivalStart");
+                    if (required <= ready)
+                    {
+                        TransitionFestival = TransitionFestival.StartingFestival;
+                        break;
+                    }
+                    break;
+
+
+                case TransitionFestival.StartingFestival:
+                    if (isEvent)
+                    {
+                        if (Festivals.IsHostDecidingNextStep)
+                        {
+                            // Don't enable chat box on spirit's eve nor feast of the winter star
+                            festivalChatBox.Enable();
+                            TransitionFestival = TransitionFestival.AtFestivalChatBox;
+                        }
+                        else
+                        {
+                            TransitionFestival = TransitionFestival.AtFestival;
+                        }
+                    }
+                    break;
+
+
+                case TransitionFestival.FestivalIsOver:
+                    ;
+                    break;
+
+
+                case TransitionFestival.AtFestivalChatBox:
+                    festivalChatBox.CheckVisible();
+
+                    var peopleVoted = festivalChatBox.NumberOfPeopleWhoVoted();
+                    var numberVoters = festivalChatBox.NumberOfVoters();
+
+                    if (peopleVoted >= numberVoters)
+                    {
+                        if (0 == peopleVoted)
+                        {
+                            OnEventMassDisconnect();
+                        }
+
+                        SendChatMessage($"{peopleVoted} / {numberVoters} votes casted. Starting the festival event...");
 
                         if (Festivals.IsTodayLuau && Game1.player.team.luauIngredients.Count > 0)
                         {
@@ -64,15 +156,60 @@ namespace DedicatedServer.HostAutomatorStages
                         }
                         Game1.CurrentEvent.answerDialogueQuestion(null, "yes");
 
-                        DisableFestivalChatBox();
-                    }
-                    else
-                    {
-                        SendChatMessage($"{voteCounts.Item1} / {voteCounts.Item2} votes casted.");
-                    }
-                }
+                        festivalChatBox.Disable();
 
-                //WaitTime = 0;
+                        TransitionFestival = TransitionFestival.EndingFestival;
+                        break;
+                    }
+
+                    ready = Game1.netReady.GetNumberReady("festivalEnd");
+                    if (0 < ready)
+                    {
+                        throw new Exception("Does this happen anytime?");
+                    }
+
+                    break;
+
+
+                case TransitionFestival.AtFestival:
+                    ready = Game1.netReady.GetNumberReady("festivalEnd");
+                    if (0 < ready)
+                    {
+                        TransitionFestival = TransitionFestival.SomeoneWantsToLeaveTheFestival;
+                        WaitForFestivalEnd();
+                        break;
+                    }
+                    
+                    break;
+
+                case TransitionFestival.SomeoneWantsToLeaveTheFestival:
+                    ready = Game1.netReady.GetNumberReady("festivalEnd");
+                    if (1 >= ready)
+                    {
+                        TransitionFestival = TransitionFestival.AtFestival;
+                        StopWaitingForFestivalEnd();
+                        break;
+                    }
+
+                    required = Game1.netReady.GetNumberRequired("festivalEnd");
+                    if (required <= ready)
+                    {
+                        TransitionFestival = TransitionFestival.EndingFestival;
+                        break;
+                    }
+                    break;
+
+                case TransitionFestival.EndingFestival:
+                    if (false == isEvent)
+                    {
+                        TransitionFestival = TransitionFestival.FestivalIsOver;
+                        break;
+                    }
+                    break;
+
+
+                default:
+                    throw new Exception($"All states of 'TransitionFestival' are set, ({_transitionFestival}) is unknown.");
             }
         }
 
@@ -80,89 +217,142 @@ namespace DedicatedServer.HostAutomatorStages
 
         private static readonly MethodInfo info = typeof(Game1).GetMethod("performWarpFarmer", BindingFlags.Static | BindingFlags.NonPublic);
 
-        private readonly FestivalChatBox festivalChatBox;
+        private TransitionFestival _transitionFestival = default;
+        
+        public TransitionFestival TransitionFestival
+        {
+            get => _transitionFestival;
+            private set
+            {
+                _transitionFestival = value;
+                OnTransitionFestivalChanged();
+            }
+        }
 
-        private int numFestivalStartVotes = 0;
-        private int numFestivalStartVotesRequired = 0;
+        /// <summary>
+        /// Called if the property <see cref="TransitionFestival"/> is changed.
+        /// </summary>
+        public event EventHandler<TransitionFestival> TransitionFestivalChanged;
+
+        /// <summary>
+        /// Called when the event starts.
+        /// </summary>
+        public event EventHandler EventStarting;
+
+        /// <summary>
+        /// Called after the event has started.
+        /// </summary>
+        public event EventHandler EventStarted;
+
+        /// <summary>
+        /// Called when the event ends.
+        /// </summary>
+        public event EventHandler EventEnding;
+
+        /// <summary>
+        /// Called after the event has ended.
+        /// </summary>
+        public event EventHandler EventEnded;
+
+        /// <summary>
+        /// Called when all players have left the server.
+        /// </summary>
+        public event EventHandler EventMassDisconnect;
+
+        private readonly FestivalChatBox festivalChatBox;
 
         public TransitionFestivalAttendanceBehaviorLink()
         {
-            MainController.helper.Events.GameLoop.DayStarted += NewDay;
+            MainController.helper.Events.GameLoop.DayStarted += OnDayStarted;
+            MainController.helper.Events.GameLoop.DayEnding += OnDayEnding;
+
+#warning Debug
+            TransitionFestivalChanged += (o, t) => SendChatMessage($"state: {t.ToString()}");
+
+            TransitionFestivalChanged += TransitionFestivalChangedHandler;
+            EventMassDisconnect += (o, s) => Sleeping.ShouldSleepOverwrite = true;
+
 
             festivalChatBox = new FestivalChatBox();
+            EventStarted += festivalChatBox.EventStarted;
         }
 
         ~TransitionFestivalAttendanceBehaviorLink() => Dispose();
 
         public void Dispose()
         {
-            MainController.helper.Events.GameLoop.DayStarted -= NewDay;
-            DisableFestivalChatBox();
-        }
-
-        public Tuple<int, int> UpdateFestivalStartVotes()
-        {
-            if (festivalChatBox.IsEnabled())
-            {
-                int numFestivalStartVotes = festivalChatBox.NumVoted();
-                if (numFestivalStartVotes != this.numFestivalStartVotes || MainController.NumberOfPlayers != numFestivalStartVotesRequired)
-                {
-                    this.numFestivalStartVotes = numFestivalStartVotes;
-                    numFestivalStartVotesRequired = MainController.NumberOfPlayers;
-                    return Tuple.Create(numFestivalStartVotes, numFestivalStartVotesRequired);
-                }
-            }
-            return null;
-        }
-
-        public void EnableFestivalChatBox()
-        {
-            festivalChatBox.Enable();
-            numFestivalStartVotes = 0;
-            numFestivalStartVotesRequired = MainController.NumberOfPlayers;
-        }
-
-        public void DisableFestivalChatBox()
-        {
             festivalChatBox.Disable();
+            EventStarted -= festivalChatBox.EventStarted;
+
+
+            MainController.helper.Events.GameLoop.DayStarted -= OnDayStarted;
+            MainController.helper.Events.GameLoop.DayEnding -= OnDayEnding;
         }
 
-        public void NewDay(object sender, DayStartedEventArgs e)
+        private void OnDayStarted(object sender, DayStartedEventArgs e)
         {
-            numFestivalStartVotes = 0;
-            numFestivalStartVotesRequired = MainController.NumberOfPlayers;
+            TransitionFestival = (Festivals.IsFestivalDay())
+                ? TransitionFestival.FestivalDay
+                : TransitionFestival.NoFestivalDay;
         }
 
-        public void SendChatMessage(string message)
+        private void OnDayEnding(object sender, DayEndingEventArgs e)
         {
-            festivalChatBox.SendChatMessage(message);
+            TransitionFestival = TransitionFestival.Uninit;
         }
 
-        private static string GetLocationOfFestival()
+        private void OnTransitionFestivalChanged()
+            => TransitionFestivalChanged?.Invoke(this, TransitionFestival);
+
+        private void TransitionFestivalChangedHandler(object sender, TransitionFestival transitionFestival)
         {
-            if (1 == Game1.weatherIcon)
+            switch (transitionFestival)
             {
-                return Game1.temporaryContent.Load<Dictionary<string, string>>("Data\\Festivals\\" + Game1.currentSeason + Game1.dayOfMonth)["conditions"].Split('/')[0];
-            }
+                case TransitionFestival.StartingFestival:
+                    OnEventStarting();
+                    break;
 
-            return null;
+                case TransitionFestival.AtFestivalChatBox:
+                case TransitionFestival.AtFestival:
+                    OnEventStarted();
+                    break;
+
+                case TransitionFestival.EndingFestival:
+                    OnEventEnding();
+                    break;
+
+                case TransitionFestival.FestivalIsOver:
+                    OnEventEnded();
+                    break;
+            }
         }
 
+        private void OnEventStarting()
+            => EventStarting?.Invoke(this, EventArgs.Empty);
+
+        private void OnEventStarted()
+            => EventStarted?.Invoke(this, EventArgs.Empty);
+
+        private void OnEventEnding()
+            => EventEnding?.Invoke(this, EventArgs.Empty);
+
+        private void OnEventEnded()
+            => EventEnded?.Invoke(this, EventArgs.Empty);
+
+
+        private void OnEventMassDisconnect()
+            => EventMassDisconnect?.Invoke(this, EventArgs.Empty);
+
+        
         private void WaitForFestivalAttendance()
         {
-            var location = Game1.getLocationFromName(GetLocationOfFestival());
+            var location = Game1.getLocationFromName(Festivals.GetLocationOfFestival());
             var warp = new Warp(0, 0, location.NameOrUniqueName, 0, 0, false);
             Game1.netReady.SetLocalReady("festivalStart", ready: true);
             Game1.activeClickableMenu = new ReadyCheckDialog("festivalStart", allowCancel: true, delegate (Farmer who)
             {
                 Game1.exitActiveMenu();
                 info.Invoke(null, new object[] { Game1.getLocationRequest(warp.TargetName), 0, 0, Game1.player.facingDirection.Value });
-
-                if (Festivals.IsHostDecidingNextStep)
-                {
-                    // Don't enable chat box on spirit's eve nor feast of the winter star
-                    EnableFestivalChatBox();
-                }
             });
 
             // Wait for festival attendance
@@ -185,7 +375,7 @@ namespace DedicatedServer.HostAutomatorStages
             Game1.activeClickableMenu = new ReadyCheckDialog("festivalEnd", allowCancel: true, delegate (Farmer who)
             {
                 Game1.currentLocation.currentEvent.forceEndFestival(who);
-                DisableFestivalChatBox();
+                festivalChatBox.Disable();
             });
 
             // Wait for festival end
@@ -201,5 +391,9 @@ namespace DedicatedServer.HostAutomatorStages
 
             // Stop waiting for festival end;
         }
+
+
+        private static void SendChatMessage(string message)
+            => MainController.chatBox.textBoxEnter(message);
     }
 }

--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -10,25 +10,43 @@ namespace DedicatedServer.HostAutomatorStages
 {
     enum TransitionFestival
     {
-        Uninit = 0, // default value and set at each end of the day
+        /// <summary> default value and set at each end of the day </summary>
+        Uninit = 0,
 
-        NoFestivalDay, // set after the day is started
-        FestivalDay, // set after the day is started
+        /// <summary> Set after the day is started </summary>
+        NoFestivalDay,
 
-        FestivalNotStarted,
+        /// <summary> Set after the day is started, waits for the participation time slot </summary>
+        FestivalDay,
+
+
+        /// <summary> This status is achieved as soon as the time slot for participating in the festival has been reached. </summary>
         FestivalGoingOn,
-        FestivalIsOver,
 
-        SomeoneWantsToGoTheFestival,
+        /// <summary> Someone wants to go the festival </summary>
+        WaitingForFestivalAttendance,
 
+        /// <summary> Transition period until the game starts the festival </summary>
         StartingFestival,
 
+        /// <summary> The festival has the option to launch an event </summary>
         AtFestivalChatBox,
+
+        /// <summary> The festival does not offer any special events. </summary>
         AtFestival,
 
-        SomeoneWantsToLeaveTheFestivalChatBox,
-        SomeoneWantsToLeaveTheFestival,
+        /// <summary> Someone wants to leave the festival (from chatbox) </summary>
+        WaitingForFestivalEndChatBox,
+
+        /// <summary> Someone wants to leave the festival </summary>
+        WaitingForFestivalEnd,
+
+        /// <summary> Transition period until the game ends the festival </summary>
         EndingFestival,
+
+
+        /// <summary> The festival is over </summary>
+        FestivalIsOver,        
     }
 
     internal class TransitionFestivalAttendanceBehaviorLink : BehaviorLink
@@ -47,12 +65,8 @@ namespace DedicatedServer.HostAutomatorStages
             switch (TransitionFestival)
             {
                 case TransitionFestival.Uninit:
-                    ;
-                    break;
-
-
                 case TransitionFestival.NoFestivalDay:
-                    ;
+                case TransitionFestival.FestivalIsOver:
                     break;
 
 
@@ -75,14 +89,14 @@ namespace DedicatedServer.HostAutomatorStages
                     ready = Game1.netReady.GetNumberReady("festivalStart");
                     if (0 < ready)
                     {
-                        TransitionFestival = TransitionFestival.SomeoneWantsToGoTheFestival;
+                        TransitionFestival = TransitionFestival.WaitingForFestivalAttendance;
                         WaitForFestivalAttendance();
                         break;
                     }
                     break;
 
 
-                case TransitionFestival.SomeoneWantsToGoTheFestival:
+                case TransitionFestival.WaitingForFestivalAttendance:
                     if (false == Festivals.IsTheFestivalGoingOn())
                     {
                         TransitionFestival = TransitionFestival.FestivalIsOver;
@@ -90,7 +104,7 @@ namespace DedicatedServer.HostAutomatorStages
                     }
 
                     ready = Game1.netReady.GetNumberReady("festivalStart");
-                    if (1>= ready)
+                    if (1 >= ready)
                     {
                         TransitionFestival = TransitionFestival.FestivalGoingOn;
                         StopWaitingForFestivalAttendance();
@@ -130,14 +144,9 @@ namespace DedicatedServer.HostAutomatorStages
                         {
                             TransitionFestival = TransitionFestival.AtFestival;
                         }
+                        break;
                     }
                     break;
-
-
-                case TransitionFestival.FestivalIsOver:
-                    ;
-                    break;
-
 
                 case TransitionFestival.AtFestivalChatBox:
                     festivalChatBox.CheckVisible();
@@ -175,14 +184,13 @@ namespace DedicatedServer.HostAutomatorStages
                             ? TransitionFestival.AtFestival
                             : TransitionFestival.EndingFestival;
 
-
                         break;
                     }
 
                     ready = Game1.netReady.GetNumberReady("festivalEnd");
                     if (0 < ready)
                     {
-                        TransitionFestival = TransitionFestival.SomeoneWantsToLeaveTheFestivalChatBox;
+                        TransitionFestival = TransitionFestival.WaitingForFestivalEndChatBox;
                         WaitForFestivalEnd();
                         break;
                     }
@@ -204,14 +212,14 @@ namespace DedicatedServer.HostAutomatorStages
                     ready = Game1.netReady.GetNumberReady("festivalEnd");
                     if (0 < ready)
                     {
-                        TransitionFestival = TransitionFestival.SomeoneWantsToLeaveTheFestival;
+                        TransitionFestival = TransitionFestival.WaitingForFestivalEnd;
                         WaitForFestivalEnd();
                         break;
                     }
                     
                     break;
 
-                case TransitionFestival.SomeoneWantsToLeaveTheFestivalChatBox:
+                case TransitionFestival.WaitingForFestivalEndChatBox:
                     ready = Game1.netReady.GetNumberReady("festivalEnd");
                     if (1 >= ready)
                     {
@@ -228,7 +236,7 @@ namespace DedicatedServer.HostAutomatorStages
                     }
                     break;
 
-                case TransitionFestival.SomeoneWantsToLeaveTheFestival:
+                case TransitionFestival.WaitingForFestivalEnd:
                     ready = Game1.netReady.GetNumberReady("festivalEnd");
                     if (1 >= ready)
                     {
@@ -253,7 +261,6 @@ namespace DedicatedServer.HostAutomatorStages
                         // up at the festival without any NPCs. This can be fixed by
                         // logging out and back in, but this way, the day just runs smoothly.
                         OnEventMassDisconnect();
-                        break;
                     }
 
                     if (false == isEvent)
@@ -411,7 +418,9 @@ namespace DedicatedServer.HostAutomatorStages
             }
         }
 
-        
+
+        #region Controls whether the host joins or leaves an event
+
         private void WaitForFestivalAttendance()
         {
             var location = Game1.getLocationFromName(Festivals.GetLocationOfFestival());
@@ -459,6 +468,8 @@ namespace DedicatedServer.HostAutomatorStages
 
             // Stop waiting for festival end;
         }
+
+        #endregion
 
 
         private static void SendChatMessage(string message)

--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -149,6 +149,7 @@ namespace DedicatedServer.HostAutomatorStages
                     break;
 
                 case TransitionFestival.AtFestivalChatBox:
+                    festivalChatBox.Update();
                     festivalChatBox.CheckVisible();
 
                     var peopleVoted = festivalChatBox.NumberOfPeopleWhoVoted();

--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -44,7 +44,6 @@ namespace DedicatedServer.HostAutomatorStages
         /// <summary> Transition period until the game ends the festival </summary>
         EndingFestival,
 
-
         /// <summary> The festival is over </summary>
         FestivalIsOver,        
     }
@@ -185,6 +184,8 @@ namespace DedicatedServer.HostAutomatorStages
                             ? TransitionFestival.AtFestival
                             : TransitionFestival.EndingFestival;
 
+                        DelayForDanceOfTheMoonlightJellies();
+
                         break;
                     }
 
@@ -206,6 +207,7 @@ namespace DedicatedServer.HostAutomatorStages
                         // the host must end the event 
                         OnEventMassDisconnect();
                         TransitionFestival = TransitionFestival.EndingFestival;
+                        DelayForDanceOfTheMoonlightJellies();
                         WaitForFestivalEnd();
                         break;
                     }
@@ -233,6 +235,7 @@ namespace DedicatedServer.HostAutomatorStages
                     if (required <= ready)
                     {
                         TransitionFestival = TransitionFestival.EndingFestival;
+                        DelayForDanceOfTheMoonlightJellies();
                         break;
                     }
                     break;
@@ -250,6 +253,7 @@ namespace DedicatedServer.HostAutomatorStages
                     if (required <= ready)
                     {
                         TransitionFestival = TransitionFestival.EndingFestival;
+                        DelayForDanceOfTheMoonlightJellies();
                         break;
                     }
                     break;
@@ -419,12 +423,25 @@ namespace DedicatedServer.HostAutomatorStages
             }
         }
 
+        /// <summary>
+        ///         The "Dance of the Moonlight Jellies" festival creates a new festival
+        /// <br/>   after the first one, so a waiting period must be observed; otherwise,
+        /// <br/>   the next state will be triggered too early.
+        /// </summary>
+        private void DelayForDanceOfTheMoonlightJellies()
+        {
+            if (Festivals.IsTodayDanceOfTheMoonlightJellies)
+            {
+                WaitTime = 60 * 15;
+            }
+        }
+                    
 
         #region Controls whether the host joins or leaves an event
 
         private void WaitForFestivalAttendance()
         {
-            var location = Game1.getLocationFromName(Festivals.GetLocationOfFestival());
+            var location = Game1.getLocationFromName(Festivals.GetStandardLocationOfFestival());
             var warp = new Warp(0, 0, location.NameOrUniqueName, 0, 0, false);
             Game1.netReady.SetLocalReady("festivalStart", ready: true);
             Game1.activeClickableMenu = new ReadyCheckDialog("festivalStart", allowCancel: true, delegate (Farmer who)

--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -1,10 +1,8 @@
 ﻿using DedicatedServer.HostAutomatorStages.BehaviorStates;
 using DedicatedServer.Utils;
-using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace DedicatedServer.HostAutomatorStages
@@ -18,25 +16,27 @@ namespace DedicatedServer.HostAutomatorStages
 
         public override void Process()
         {
-            if (Utils.Festivals.ShouldAttend(MainController.NumberOfPlayers) && 
-                false == Utils.Festivals.IsWaitingToAttend())
+            var numberOfPlayers = MainController.NumberOfPlayers;
+
+            if (Festivals.ShouldAttend(numberOfPlayers) && 
+                false == Festivals.IsWaitingToAttend())
             {
                 WaitForFestivalAttendance();
             }
             else if (
-                false == Utils.Festivals.ShouldAttend(MainController.NumberOfPlayers) && 
-                Utils.Festivals.IsWaitingToAttend())
+                false == Festivals.ShouldAttend(numberOfPlayers) && 
+                Festivals.IsWaitingToAttend())
             {
                 StopWaitingForFestivalAttendance();
             }
-            else if(Utils.Festivals.ShouldLeave(MainController.NumberOfPlayers) &&
-                false == Utils.Festivals.IsWaitingToLeave())
+            else if(Festivals.ShouldLeave(numberOfPlayers) &&
+                false == Festivals.IsWaitingToLeave())
             {
                 WaitForFestivalEnd();
             }
             else if (
-                false == Utils.Festivals.ShouldLeave(MainController.NumberOfPlayers) &&
-                Utils.Festivals.IsWaitingToLeave())
+                false == Festivals.ShouldLeave(numberOfPlayers) &&
+                Festivals.IsWaitingToLeave())
             {
                 StopWaitingForFestivalEnd();
             }
@@ -49,7 +49,8 @@ namespace DedicatedServer.HostAutomatorStages
                     {
                         // Start the festival
                         SendChatMessage($"{voteCounts.Item1} / {voteCounts.Item2} votes casted. Starting the festival event...");
-                        if (Game1.currentSeason == "summer" && Game1.dayOfMonth == 11 && Game1.player.team.luauIngredients.Count > 0)
+
+                        if (Festivals.IsTodayLuau && Game1.player.team.luauIngredients.Count > 0)
                         {
                             // If it's the Luau and the pot isn't empty, add a duplicate of someone else's item to the pot. It (mostly) doesn't matter
                             // which item is duplicated. Indeed, the total luau score is simply equal to the lowest score (or some extremum) of any item

--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -13,10 +13,13 @@ namespace DedicatedServer.HostAutomatorStages
         /// <summary> default value and set at each end of the day </summary>
         Uninit = 0,
 
-        /// <summary> Set after the day is started </summary>
+        /// <summary> Set after the day is started, 
+        /// <br/>   <see cref="TransitionFestivalAttendanceBehaviorLink.OnDayStarted"/></summary>
         NoFestivalDay,
 
-        /// <summary> Set after the day is started, waits for the participation time slot </summary>
+        /// <summary> Set after the day is started,
+        /// <br/>   <see cref="TransitionFestivalAttendanceBehaviorLink.OnDayStarted"/>,
+        /// <br/>   waits for the participation time slot </summary>
         FestivalDay,
 
 
@@ -57,8 +60,7 @@ namespace DedicatedServer.HostAutomatorStages
 
         public override void Process()
         {
-            bool isEvent = null != Game1.CurrentEvent;
-            
+            bool isEvent;
             int ready;
             int required;
             switch (TransitionFestival)
@@ -131,6 +133,7 @@ namespace DedicatedServer.HostAutomatorStages
                         break;
                     }
 
+                    isEvent = null != Game1.CurrentEvent;
                     if (isEvent)
                     {
                         if (Festivals.IsHostDecidingNextStep)
@@ -180,11 +183,15 @@ namespace DedicatedServer.HostAutomatorStages
                         festivalChatBox.Disable();
 
                         // At the Stardw Valley Fair, you must manually exit the festival after the event.
-                        TransitionFestival = (Festivals.IsTodayStardewValleyFair)
-                            ? TransitionFestival.AtFestival
-                            : TransitionFestival.EndingFestival;
-
-                        DelayForDanceOfTheMoonlightJellies();
+                        if (Festivals.IsTodayStardewValleyFair)
+                        {
+                            TransitionFestival = TransitionFestival.AtFestival;
+                        }
+                        else
+                        {
+                            TransitionFestival = TransitionFestival.EndingFestival;
+                            DelayForDanceOfTheMoonlightJellies();
+                        }
 
                         break;
                     }
@@ -268,6 +275,7 @@ namespace DedicatedServer.HostAutomatorStages
                         OnEventMassDisconnect();
                     }
 
+                    isEvent = null != Game1.CurrentEvent;
                     if (false == isEvent)
                     {
                         TransitionFestival = TransitionFestival.FestivalIsOver;
@@ -338,8 +346,6 @@ namespace DedicatedServer.HostAutomatorStages
             MainController.helper.Events.GameLoop.DayStarted += OnDayStarted;
             MainController.helper.Events.GameLoop.DayEnding += OnDayEnding;
 
-#warning Debug
-            TransitionFestivalChanged += (o, t) => SendChatMessage($"state: {t.ToString()}");
 
             TransitionFestivalChanged += TransitionFestivalChangedHandler;
             EventMassDisconnect += (o, s) => Sleeping.ShouldSleepOverwrite = true;
@@ -376,7 +382,9 @@ namespace DedicatedServer.HostAutomatorStages
         }
 
         private void OnTransitionFestivalChanged()
-            => TransitionFestivalChanged?.Invoke(this, TransitionFestival);
+        {
+            TransitionFestivalChanged?.Invoke(this, TransitionFestival);
+        }
 
         private void TransitionFestivalChangedHandler(object sender, TransitionFestival transitionFestival)
         {
@@ -413,7 +421,7 @@ namespace DedicatedServer.HostAutomatorStages
         private void OnEventEnded()
             => EventEnded?.Invoke(this, EventArgs.Empty);
 
-
+        
         private void OnEventMassDisconnect()
         {
             if (false == _hasEventMassDisconnectInvokedBefore)

--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -1,4 +1,5 @@
 ﻿using DedicatedServer.HostAutomatorStages.BehaviorStates;
+using DedicatedServer.Utils;
 using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
@@ -156,9 +157,7 @@ namespace DedicatedServer.HostAutomatorStages
                 Game1.exitActiveMenu();
                 info.Invoke(null, new object[] { Game1.getLocationRequest(warp.TargetName), 0, 0, Game1.player.facingDirection.Value });
 
-                if ((Game1.currentSeason != "fall" || Game1.dayOfMonth != 27) &&
-                    (Game1.currentSeason != "winter" || Game1.dayOfMonth != 25)
-                )
+                if (Festivals.IsHostDecidingNextStep)
                 {
                     // Don't enable chat box on spirit's eve nor feast of the winter star
                     EnableFestivalChatBox();

--- a/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
+++ b/DedicatedServer/HostAutomatorStages/BehaviorStates/TransitionFestivalAttendanceBehaviorLink.cs
@@ -26,6 +26,7 @@ namespace DedicatedServer.HostAutomatorStages
         AtFestivalChatBox,
         AtFestival,
 
+        SomeoneWantsToLeaveTheFestivalChatBox,
         SomeoneWantsToLeaveTheFestival,
         EndingFestival,
     }
@@ -100,12 +101,23 @@ namespace DedicatedServer.HostAutomatorStages
                     if (required <= ready)
                     {
                         TransitionFestival = TransitionFestival.StartingFestival;
+                        _timeout = Game1.timeOfDay + 30;
                         break;
                     }
                     break;
 
 
                 case TransitionFestival.StartingFestival:
+                    if (_timeout <= Game1.timeOfDay)
+                    {
+                        // This is only necessary if I want to go to a festival at the last minute
+                        // but a cutscene pops up. In that case, the game doesn't switch to the
+                        // festival, and the state machine freezes.
+                        TransitionFestival = TransitionFestival.FestivalGoingOn;
+                        StopWaitingForFestivalAttendance();
+                        break;
+                    }
+
                     if (isEvent)
                     {
                         if (Festivals.IsHostDecidingNextStep)
@@ -158,20 +170,37 @@ namespace DedicatedServer.HostAutomatorStages
 
                         festivalChatBox.Disable();
 
-                        TransitionFestival = TransitionFestival.EndingFestival;
+                        // At the Stardw Valley Fair, you must manually exit the festival after the event.
+                        TransitionFestival = (Festivals.IsTodayStardewValleyFair)
+                            ? TransitionFestival.AtFestival
+                            : TransitionFestival.EndingFestival;
+
+
                         break;
                     }
 
                     ready = Game1.netReady.GetNumberReady("festivalEnd");
                     if (0 < ready)
                     {
-                        throw new Exception("Does this happen anytime?");
+                        TransitionFestival = TransitionFestival.SomeoneWantsToLeaveTheFestivalChatBox;
+                        WaitForFestivalEnd();
+                        break;
                     }
 
                     break;
 
 
                 case TransitionFestival.AtFestival:
+                    if (0 == MainController.NumberOfPlayers)
+                    {
+                        // In a real festival, no player can join; if all players are disconnected,
+                        // the host must end the event 
+                        OnEventMassDisconnect();
+                        TransitionFestival = TransitionFestival.EndingFestival;
+                        WaitForFestivalEnd();
+                        break;
+                    }
+
                     ready = Game1.netReady.GetNumberReady("festivalEnd");
                     if (0 < ready)
                     {
@@ -180,6 +209,23 @@ namespace DedicatedServer.HostAutomatorStages
                         break;
                     }
                     
+                    break;
+
+                case TransitionFestival.SomeoneWantsToLeaveTheFestivalChatBox:
+                    ready = Game1.netReady.GetNumberReady("festivalEnd");
+                    if (1 >= ready)
+                    {
+                        TransitionFestival = TransitionFestival.AtFestivalChatBox;
+                        StopWaitingForFestivalEnd();
+                        break;
+                    }
+
+                    required = Game1.netReady.GetNumberRequired("festivalEnd");
+                    if (required <= ready)
+                    {
+                        TransitionFestival = TransitionFestival.EndingFestival;
+                        break;
+                    }
                     break;
 
                 case TransitionFestival.SomeoneWantsToLeaveTheFestival:
@@ -200,6 +246,16 @@ namespace DedicatedServer.HostAutomatorStages
                     break;
 
                 case TransitionFestival.EndingFestival:
+                    if (0 == MainController.NumberOfPlayers)
+                    {
+                        // If the players are disconnected at the end, the host doesn't
+                        // completely leave the festival, and a player who logs in ends
+                        // up at the festival without any NPCs. This can be fixed by
+                        // logging out and back in, but this way, the day just runs smoothly.
+                        OnEventMassDisconnect();
+                        break;
+                    }
+
                     if (false == isEvent)
                     {
                         TransitionFestival = TransitionFestival.FestivalIsOver;
@@ -260,6 +316,10 @@ namespace DedicatedServer.HostAutomatorStages
         public event EventHandler EventMassDisconnect;
 
         private readonly FestivalChatBox festivalChatBox;
+        
+        private bool _hasEventMassDisconnectInvokedBefore = false;
+
+        private int _timeout;
 
         public TransitionFestivalAttendanceBehaviorLink()
         {
@@ -294,6 +354,8 @@ namespace DedicatedServer.HostAutomatorStages
             TransitionFestival = (Festivals.IsFestivalDay())
                 ? TransitionFestival.FestivalDay
                 : TransitionFestival.NoFestivalDay;
+
+            _hasEventMassDisconnectInvokedBefore = false;
         }
 
         private void OnDayEnding(object sender, DayEndingEventArgs e)
@@ -341,7 +403,13 @@ namespace DedicatedServer.HostAutomatorStages
 
 
         private void OnEventMassDisconnect()
-            => EventMassDisconnect?.Invoke(this, EventArgs.Empty);
+        {
+            if (false == _hasEventMassDisconnectInvokedBefore)
+            {
+                _hasEventMassDisconnectInvokedBefore = true;
+                EventMassDisconnect?.Invoke(this, EventArgs.Empty);
+            }
+        }
 
         
         private void WaitForFestivalAttendance()

--- a/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
+++ b/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
@@ -9,22 +9,46 @@ namespace DedicatedServer.HostAutomatorStages
 {
     class FarmerDecisionDto
     {
+        public Farmer Farmer { get; set; } = null;
         public bool Vote { get; set; } = false;
+        public bool InFront { get; set; } = false;
         public bool Visible { get; set; } = false;
+        public DateTime Timeout { get; set; } = DateTime.MaxValue;
+
+        public FarmerDecisionDto(Farmer farmer)
+        {
+            Farmer = farmer;
+        }
     }
 
     internal class FestivalChatBox
     {
-        private const string entryMessage = "When you wish to start the festival, type \"start\" into chat. If you'd like to cancel your vote, type \"cancel\".";
+        public event EventHandler InFrontEntered;
+        public event EventHandler InFrontExited;
 
-        public Dictionary<long, FarmerDecisionDto> FarmerDecision = new();
+        public event EventHandler VisibleEntered;
+        public event EventHandler VisibleExited;
 
-        public NPC Lewis { get; private set; }
+        private const string entryMessage1 = "When you wish to start the festival, type \"start\" into chat.";
+        private const string entryMessage2 = "If you'd like to cancel your vote, type \"cancel\".";
+        private const string entryMessage3 = "If you stand for Lewis for {0} seconds, that counts as a request to start.";
+
+        private Dictionary<long, FarmerDecisionDto> FarmerDecision = new();
+
+        private NPC Lewis { get; set; }
 
         private bool enabled = false;
 
+        private const int WaitTimeSeconds = 10;
+
         public FestivalChatBox()
         {
+#warning Debug
+            InFrontEntered += (s, e) => SendChatMessage($"In range");
+            InFrontExited += (s, e) => SendChatMessage($"Out range");
+
+            VisibleEntered += (s, e) => SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
+            VisibleExited += (s, e) => SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
         }
 
         public bool IsEnabled()
@@ -38,8 +62,11 @@ namespace DedicatedServer.HostAutomatorStages
 
                 Update();
 
-                MainController.chatBox.textBoxEnter(entryMessage);
                 MainController.chatBox.ChatReceived += OnChatReceived;
+
+                MainController.chatBox.textBoxEnter(entryMessage1);
+                MainController.chatBox.textBoxEnter(entryMessage2);
+                MainController.chatBox.textBoxEnter(string.Format(entryMessage3, WaitTimeSeconds));
             }
         }
 
@@ -62,47 +89,32 @@ namespace DedicatedServer.HostAutomatorStages
             Lewis = Npc.GetNpc("Lewis");
         }
 
-        public void CheckVisible()
-        {
-            foreach (var farmer in Game1.otherFarmers.Values.ToList())
-            {
-                if (Npc.IsFarmerInFront(farmer, Lewis, 2, 0))
-                {
-                    VisibleStart(farmer.UniqueMultiplayerID);
-                }
-                else
-                {
-                    VisibleCancel(farmer.UniqueMultiplayerID);
-                }
-            }
-        }
 
-        public int NumberOfPeopleWhoVoted()
-        {
-            if (false == enabled) { return -1; }
+        private void OnInFrontEntered()
+            => InFrontEntered?.Invoke(this, EventArgs.Empty);
 
-            if (MainController.NumberOfPlayers != FarmerDecision.Count)
-            {
-                Update();
-            }
+        private void OnInFrontExited()
+            => InFrontExited?.Invoke(this, EventArgs.Empty);
 
-            return FarmerDecision.Count(f => f.Value.Visible || f.Value.Vote);
-        }
+        private void OnVisibleEntered()
+            => VisibleEntered?.Invoke(this, EventArgs.Empty);
 
-        public int NumberOfVoters()
-        {
-            if (false == enabled){ return -1; }
+        private void OnVisibleExited()
+            => VisibleExited?.Invoke(this, EventArgs.Empty);
 
-            if (MainController.NumberOfPlayers != FarmerDecision.Count)
-            {
-                Update();
-            }
-
-            return FarmerDecision.Count();
-        }
-
+        /// <summary>
+        ///         Updates the <see cref="FarmerDecision"/> dictionary, must be called periodically.
+        /// <br/> 
+        /// <br/>   Only if the number of players (<see cref="MainController.NumberOfPlayers"/>)
+        /// <br/>   does not match the current number of players in the dictionary.
+        /// <br/>   This works because no new players can join during an event.
+        /// <br/>   The only possibility is for a connection to be interrupted,
+        /// <br/>   which reduces the number of players.
+        /// </summary>
         public void Update()
         {
+            if (MainController.NumberOfPlayers == FarmerDecision.Count) { return; }
+
             var dummy = new Dictionary<long, FarmerDecisionDto>();
             FarmerDecisionDto item;
             foreach (var farmer in MainController.OnlineFarmers())
@@ -113,37 +125,70 @@ namespace DedicatedServer.HostAutomatorStages
                 }
                 else
                 {
-                    dummy.Add(farmer.Key, new FarmerDecisionDto());
-                }  
+                    dummy.Add(farmer.Key, new FarmerDecisionDto(farmer.Value));
+                }
             }
 
             FarmerDecision = dummy;
         }
 
-        private void VisibleStart(long id)
+        public void CheckVisible()
         {
-            if (false == FarmerDecision.TryGetValue(id, out var item)) { return; }
-
-            if (item.Vote) { return; }
-
-            if (false == item.Visible)
+            foreach (var dto in FarmerDecision.Values)
             {
-                item.Visible = true;
-                SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
+#error What is this I used values to get the item???
+                if (false == FarmerDecision.TryGetValue(dto.Farmer.UniqueMultiplayerID, out var item)) { continue; }
+
+                if (Npc.IsFarmerInFront(dto.Farmer, Lewis, 2, 0))
+                {
+                    if (item.Vote) { return; }
+
+                    if (false == item.InFront)
+                    {
+                        item.InFront = true;
+                        item.Timeout = DateTime.UtcNow.AddSeconds(WaitTimeSeconds);
+                        OnInFrontEntered();
+                    }
+                    else
+                    {
+                        if (DateTime.UtcNow >= item.Timeout)
+                        {
+                            item.Visible = true;
+                            OnVisibleEntered();
+                        }
+                    }
+                }
+                else
+                {
+                    if (item.Vote) { return; }
+
+                    if (true == item.InFront)
+                    {
+                        item.InFront = false;
+                        OnInFrontExited();
+
+                        if (true == item.Visible)
+                        {
+                            item.Visible = false;
+                            OnVisibleExited();
+                        }
+                    }
+                }
             }
         }
 
-        private void VisibleCancel(long id)
-        { 
-            if (false == FarmerDecision.TryGetValue(id, out var item)) { return; }
+        public int NumberOfPeopleWhoVoted()
+        {
+            if (false == enabled) { return -1; }
 
-            if (item.Vote) { return; }
+            return FarmerDecision.Count(f => f.Value.Visible || f.Value.Vote);
+        }
 
-            if (true == item.Visible)
-            {
-                item.Visible = false;
-                SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
-            }
+        public int NumberOfVoters()
+        {
+            if (false == enabled){ return -1; }
+
+            return FarmerDecision.Count;
         }
 
         private void OnChatReceived(object sender, ChatEventArgs e)

--- a/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
+++ b/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
@@ -51,11 +51,11 @@ namespace DedicatedServer.HostAutomatorStages
                 return;
             }
 
-            if (e.Message.ToLower() == "start")
+            if (e.Message.ToLowerInvariant() == "start")
             {
                 votes.Add(e.SourceFarmerId);
             }
-            else if (e.Message.ToLower() == "cancel")
+            else if (e.Message.ToLowerInvariant() == "cancel")
             {
                 votes.Remove(e.SourceFarmerId);
             }

--- a/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
+++ b/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
@@ -31,7 +31,7 @@ namespace DedicatedServer.HostAutomatorStages
 
         private const string entryMessage1 = "When you wish to start the festival, type \"start\" into chat.";
         private const string entryMessage2 = "If you'd like to cancel your vote, type \"cancel\".";
-        private const string entryMessage3 = "If you stand for Lewis for {0} seconds, that counts as a request to start.";
+        private const string entryMessage3 = "Standing in front of Lewis for {0} seconds, counts as start.";
 
         private Dictionary<long, FarmerDecisionDto> FarmerDecision = new();
 

--- a/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
+++ b/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
@@ -43,10 +43,6 @@ namespace DedicatedServer.HostAutomatorStages
 
         public FestivalChatBox()
         {
-#warning Debug
-            InFrontEntered += (s, e) => SendChatMessage($"In range");
-            InFrontExited += (s, e) => SendChatMessage($"Out range");
-
             VisibleEntered += (s, e) => SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
             VisibleExited += (s, e) => SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
         }
@@ -134,12 +130,9 @@ namespace DedicatedServer.HostAutomatorStages
 
         public void CheckVisible()
         {
-            foreach (var dto in FarmerDecision.Values)
+            foreach (var item in FarmerDecision.Values)
             {
-#error What is this I used values to get the item???
-                if (false == FarmerDecision.TryGetValue(dto.Farmer.UniqueMultiplayerID, out var item)) { continue; }
-
-                if (Npc.IsFarmerInFront(dto.Farmer, Lewis, 2, 0))
+                if (Npc.IsFarmerInFront(item.Farmer, Lewis, 2, 0) && false == HasMenuOpen(item.Farmer))
                 {
                     if (item.Vote) { return; }
 
@@ -225,6 +218,16 @@ namespace DedicatedServer.HostAutomatorStages
                     break;
             }
         }
+
+        /// <summary>
+        /// This is true for every menu, including a dialogue with an NPC
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <returns>
+        ///         true : A menu is open
+        /// <br/>   false: No menu is open</returns>
+        public static bool HasMenuOpen(Farmer farmer)
+            => farmer.hasMenuOpen.Value;
 
         private static void SendChatMessage(string message)
             => MainController.chatBox.textBoxEnter(message);

--- a/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
+++ b/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
@@ -144,10 +144,13 @@ namespace DedicatedServer.HostAutomatorStages
                     }
                     else
                     {
-                        if (DateTime.UtcNow >= item.Timeout)
+                        if (false == item.Visible)
                         {
-                            item.Visible = true;
-                            OnVisibleEntered();
+                            if (DateTime.UtcNow >= item.Timeout)
+                            {
+                                item.Visible = true;
+                                OnVisibleEntered();
+                            }
                         }
                     }
                 }

--- a/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
+++ b/DedicatedServer/HostAutomatorStages/FestivalChatBox.cs
@@ -1,35 +1,45 @@
 ﻿using DedicatedServer.Chat;
+using DedicatedServer.Utils;
 using StardewValley;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DedicatedServer.HostAutomatorStages
 {
+    class FarmerDecisionDto
+    {
+        public bool Vote { get; set; } = false;
+        public bool Visible { get; set; } = false;
+    }
+
     internal class FestivalChatBox
     {
         private const string entryMessage = "When you wish to start the festival, type \"start\" into chat. If you'd like to cancel your vote, type \"cancel\".";
 
-        private IDictionary<long, Farmer> otherPlayers;
+        public Dictionary<long, FarmerDecisionDto> FarmerDecision = new();
+
+        public NPC Lewis { get; private set; }
+
         private bool enabled = false;
-        private HashSet<long> votes = new HashSet<long>();
 
         public FestivalChatBox()
         {
         }
 
         public bool IsEnabled()
-        {
-            return enabled;
-        }
+            => enabled;
 
         public void Enable()
         {
-            if (!enabled)
+            if (false == enabled)
             {
                 enabled = true;
-                votes.Clear();
-                otherPlayers = MainController.OnlineFarmers();
+
+                Update();
+
                 MainController.chatBox.textBoxEnter(entryMessage);
-                MainController.chatBox.ChatReceived += onChatReceived;
+                MainController.chatBox.ChatReceived += OnChatReceived;
             }
         }
 
@@ -38,45 +48,140 @@ namespace DedicatedServer.HostAutomatorStages
             if (enabled)
             {
                 enabled = false;
-                votes.Clear();
-                otherPlayers.Clear();
-                MainController.chatBox.ChatReceived -= onChatReceived;
+
+                FarmerDecision.Clear();
+
+                Lewis = null;
+
+                MainController.chatBox.ChatReceived -= OnChatReceived;
             }
         }
 
-        private void onChatReceived(object sender, ChatEventArgs e)
+        public void EventStarted(object sender, EventArgs e)
         {
-            if (!otherPlayers.ContainsKey(e.SourceFarmerId))
-            {
-                return;
-            }
-
-            if (e.Message.ToLowerInvariant() == "start")
-            {
-                votes.Add(e.SourceFarmerId);
-            }
-            else if (e.Message.ToLowerInvariant() == "cancel")
-            {
-                votes.Remove(e.SourceFarmerId);
-            }
+            Lewis = Npc.GetNpc("Lewis");
         }
 
-        public int NumVoted()
+        public void CheckVisible()
         {
-            int count = 0;
-            foreach (var id in otherPlayers.Keys)
+            foreach (var farmer in Game1.otherFarmers.Values.ToList())
             {
-                if (votes.Contains(id))
+                if (Npc.IsFarmerInFront(farmer, Lewis, 2, 0))
                 {
-                    count++;
+                    VisibleStart(farmer.UniqueMultiplayerID);
+                }
+                else
+                {
+                    VisibleCancel(farmer.UniqueMultiplayerID);
                 }
             }
-            return count;
         }
 
-        public void SendChatMessage(string message)
+        public int NumberOfPeopleWhoVoted()
         {
-            MainController.chatBox.textBoxEnter(message);
+            if (false == enabled) { return -1; }
+
+            if (MainController.NumberOfPlayers != FarmerDecision.Count)
+            {
+                Update();
+            }
+
+            return FarmerDecision.Count(f => f.Value.Visible || f.Value.Vote);
         }
+
+        public int NumberOfVoters()
+        {
+            if (false == enabled){ return -1; }
+
+            if (MainController.NumberOfPlayers != FarmerDecision.Count)
+            {
+                Update();
+            }
+
+            return FarmerDecision.Count();
+        }
+
+        public void Update()
+        {
+            var dummy = new Dictionary<long, FarmerDecisionDto>();
+            FarmerDecisionDto item;
+            foreach (var farmer in MainController.OnlineFarmers())
+            {
+                if (FarmerDecision.TryGetValue(farmer.Key, out item))
+                {
+                    dummy.Add(farmer.Key, item);
+                }
+                else
+                {
+                    dummy.Add(farmer.Key, new FarmerDecisionDto());
+                }  
+            }
+
+            FarmerDecision = dummy;
+        }
+
+        private void VisibleStart(long id)
+        {
+            if (false == FarmerDecision.TryGetValue(id, out var item)) { return; }
+
+            if (item.Vote) { return; }
+
+            if (false == item.Visible)
+            {
+                item.Visible = true;
+                SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
+            }
+        }
+
+        private void VisibleCancel(long id)
+        { 
+            if (false == FarmerDecision.TryGetValue(id, out var item)) { return; }
+
+            if (item.Vote) { return; }
+
+            if (true == item.Visible)
+            {
+                item.Visible = false;
+                SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
+            }
+        }
+
+        private void OnChatReceived(object sender, ChatEventArgs e)
+        {
+            long id = e.SourceFarmerId;
+
+            // For example, if a player leaves the game (ChatKind = 2)
+            if (0 == id) { return; }
+
+            if (Game1.player.UniqueMultiplayerID == id) { return; }
+            
+            if (false == FarmerDecision.TryGetValue(id, out FarmerDecisionDto item)) { return; }
+
+            if (item.Visible) { return; }
+
+            switch (e.Message.ToLowerInvariant())
+            {
+                case "start":
+                    if (false == item.Vote)
+                    {
+                        item.Vote = true;
+                        SendChatMessage("Vote started");
+                        SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
+                    }
+                    break;
+
+                case "cancel":
+                    if (true == item.Vote)
+                    {
+                        item.Vote = false;
+                        SendChatMessage("Vote canceled");
+                        SendChatMessage($"{NumberOfPeopleWhoVoted()} / {NumberOfVoters()} votes casted.");
+                    }
+                    break;
+            }
+        }
+
+        private static void SendChatMessage(string message)
+            => MainController.chatBox.textBoxEnter(message);
     }
 }

--- a/DedicatedServer/MainController.cs
+++ b/DedicatedServer/MainController.cs
@@ -130,6 +130,40 @@ namespace DedicatedServer
 
         #region Game
 
+        public static void SetMonth(Season season)
+        {
+            switch (season)
+            {
+                case Season.Spring: Game1.currentSeason = "spring"; break;
+                case Season.Summer: Game1.currentSeason = "summer"; break;
+                case Season.Fall: Game1.currentSeason = "fall"; break;
+                case Season.Winter: Game1.currentSeason = "winter"; break;
+                default: break;
+            }
+        }
+
+        public static void SetMonth(int month)
+        {
+            switch (month)
+            {
+                case 1: Game1.currentSeason = "spring"; break;
+                case 2: Game1.currentSeason = "summer"; break;
+                case 3: Game1.currentSeason = "fall"; break;
+                case 4: Game1.currentSeason = "winter"; break;
+                default: break;
+            }
+        }
+
+        public static void SetDay(int day)
+        {
+            if (28 >= day && 1 <= day)
+            {
+                day = day - Game1.dayOfMonth;
+                Game1.stats.DaysPlayed += (uint)day;
+                Game1.dayOfMonth += day;
+            }
+        }
+
         /// <summary>
         ///         List of farmers of saved games
         /// </summary>

--- a/DedicatedServer/MainController.cs
+++ b/DedicatedServer/MainController.cs
@@ -19,7 +19,7 @@ namespace DedicatedServer
     {
         private static FieldInfo multiplayerFieldInfo = typeof(Game1).GetField("multiplayer", BindingFlags.NonPublic | BindingFlags.Static);
 
-        private static Multiplayer multiplayer = null;
+        private static Multiplayer multiplayer => (Multiplayer)multiplayerFieldInfo.GetValue(null);
 
         public static IModHelper helper { get; private set; }
         public static IMonitor monitor { get; private set; }
@@ -172,17 +172,95 @@ namespace DedicatedServer
         #region Players
 
         /// <summary>
-        /// Get number of all players who are currently connected
+        ///         Get number of all players who are currently connected, without the host
+        /// <br/>   
+        /// <br/>   The following does not update in an event:
+        /// <code>
+        ///   Game1.otherFarmers;
+        ///   Game1.getOnlineFarmers();
+        /// </code>
         /// </summary>
-        public static int NumberOfPlayers { get => Game1.getOnlineFarmers().Count - 1; }
+        public static int NumberOfPlayers
+        {
+            get
+            {
+                int number = 0;
+                foreach (var farmer in Game1.getOnlineFarmers())
+                {
+                    if (false == multiplayer.isDisconnecting(farmer))
+                    {
+                        number++;
+                    }
+                }
+                return number -1;
+            }
+        }
 
+        /// <summary>
+        ///         Get number of all players who are currently connected, without the host
+        /// <br/>   
+        /// <br/>   Attention: This property does not update in an event.
+        /// </summary>
+        public static int NumberOfPlayersNoneEventUpdate
+        {
+            get => Game1.getOnlineFarmers().Count - 1;
+        }
+        
+        /// <summary>
+        ///         Get a List of online farmers, without the host
+        /// <br/>   
+        /// <br/>   The following does not update in an event:
+        /// <code>
+        ///   Game1.otherFarmers;
+        ///   Game1.getOnlineFarmers();
+        /// </code>
+        /// </summary>
+        /// <returns>List of online farmers</returns>
+        public static List<Farmer> GetOnlineFarmers()
+        {
+            var onlineFarmers = new List<Farmer>();
+            foreach (var farmer in Game1.getOnlineFarmers())
+            {
+                if (Game1.player.UniqueMultiplayerID == farmer.UniqueMultiplayerID) { continue; }
+
+                if (false == multiplayer.isDisconnecting(farmer))
+                {
+                    onlineFarmers.Add(farmer);
+                }
+            }
+            return onlineFarmers;
+        }
+
+        /// <summary>
+        ///         Get a List of online farmers, without the host
+        /// <br/>   
+        /// <br/>   Attention: This function does not update in an event.
+        /// </summary>
+        /// <returns>List of online farmers</returns>
+        public static List<Farmer> GetOnlineFarmersNoneEventUpdate()
+        {
+            var onlineFarmers = new List<Farmer>();
+            foreach (var farmer in Game1.getOnlineFarmers())
+            {
+                if (Game1.player.UniqueMultiplayerID == farmer.UniqueMultiplayerID) { continue; }
+
+                onlineFarmers.Add(farmer);
+            }
+            return onlineFarmers;
+        }
+
+        /// <summary>
+        ///         Get a Dictionary of online farmers, without the host
+        /// <br/>   
+        /// <br/>   The following does not update in an event:
+        /// <code>
+        ///   Game1.otherFarmers;
+        ///   Game1.getOnlineFarmers();
+        /// </code>
+        /// </summary>
+        /// <returns>Dictionary of online farmers</returns>
         public static Dictionary<long, Farmer> OnlineFarmers()
         {
-            if (multiplayer == null)
-            {
-                multiplayer = (Multiplayer)multiplayerFieldInfo.GetValue(null);
-            }
-
             var otherPlayers = new Dictionary<long, Farmer>();
             
             foreach (var farmer in Game1.otherFarmers.Values)

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -300,14 +300,14 @@ namespace DedicatedServer.MessageCommands
                         }
                         break;
 
+                    case "settomonth":
+                        int month = int.TryParse(param, out int resultMonth) ? resultMonth : 0;
+                        MainController.SetMonth(month);
+                        break;
+
                     case "settoday":
-                        int days = int.TryParse(param, out int result) ? result : 0;
-                        if (28 >= days && 0 < days)
-                        {
-                            days = days - Game1.dayOfMonth;
-                            Game1.stats.DaysPlayed += (uint)days;
-                            Game1.dayOfMonth += days;
-                        }
+                        int day = int.TryParse(param, out int resultDay) ? resultDay : 0;
+                        MainController.SetDay(day);
                         break;
 
                     case "seed":

--- a/DedicatedServer/MessageCommands/ServerCommandListener.cs
+++ b/DedicatedServer/MessageCommands/ServerCommandListener.cs
@@ -282,6 +282,16 @@ namespace DedicatedServer.MessageCommands
                     #region DEBUG_COMMANDS
                     #if USE_DEBUG
 
+                    case "t9":
+                        Game1.timeOfDay = 900;
+                        break;
+                    case "t18":
+                        Game1.timeOfDay = 1800;
+                        break;
+                    case "t22":
+                        Game1.timeOfDay = 2200;
+                        break;
+
                     case "timereset":
                         if (Game1.dayOfMonth > 1)
                         {
@@ -292,7 +302,7 @@ namespace DedicatedServer.MessageCommands
 
                     case "settoday":
                         int days = int.TryParse(param, out int result) ? result : 0;
-                        if (days > Game1.dayOfMonth)
+                        if (28 >= days && 0 < days)
                         {
                             days = days - Game1.dayOfMonth;
                             Game1.stats.DaysPlayed += (uint)days;

--- a/DedicatedServer/Utils/Festivals.cs
+++ b/DedicatedServer/Utils/Festivals.cs
@@ -29,7 +29,7 @@ namespace DedicatedServer.Utils
         }
         public static bool ShouldAttend(int numOtherPlayers)
         {
-            return numOtherPlayers > 0 && OthersWaitingToAttend(numOtherPlayers) && Utility.isFestivalDay(Game1.dayOfMonth, Game1.season) && !isTodayBeachNightMarket() && Game1.timeOfDay >= Utility.getStartTimeOfFestival() && Game1.timeOfDay <= getFestivalEndTime();
+            return numOtherPlayers > 0 && OthersWaitingToAttend(numOtherPlayers) && Utility.isFestivalDay() && !isTodayBeachNightMarket() && Game1.timeOfDay >= Utility.getStartTimeOfFestival() && Game1.timeOfDay <= getFestivalEndTime();
         }
 
         public static bool IsWaitingToLeave()

--- a/DedicatedServer/Utils/Festivals.cs
+++ b/DedicatedServer/Utils/Festivals.cs
@@ -10,8 +10,81 @@ namespace DedicatedServer.Utils
         #region Festivals
 
         /// <summary>
+        ///         Find out if there's a specific festival taking place today.
+        /// <br/>   The original functions are:
+        /// <br/>   <see cref="Utility.isFestivalDay()"/>
+        /// <br/>   <see cref="Utility.IsPassiveFestivalDay()"/>
+        /// </summary>
+        public static bool IsTodaySpecificFestival
+        { 
+            get
+            {
+                var day = Game1.dayOfMonth;
+                return Game1.currentSeason switch
+                {
+                    "spring" => day is 13 or 15 or 16 or 17 or 24,
+                    "summer" => day is 11 or 20 or 21 or 28,
+                    "fall" => day is 16 or 27,
+                    "winter" => day is 8 or 12 or 13 or 15 or 16 or 17 or 25,
+                    _ => false
+                };
+            }
+        }
+
+        public static string GetFestivalName()
+        {
+            var day = Game1.dayOfMonth;
+            switch (Game1.currentSeason)
+            {
+                case "spring":
+                    switch (Game1.dayOfMonth)
+                    {
+                        case 13: return "Egg Festival";
+                        case 15:
+                        case 16:
+                        case 17: return "Desert Festival";
+                        case 24: return "Flower Dance";
+                        default: return null;
+                    }
+                case "summer":
+                    switch (Game1.dayOfMonth)
+                    {
+                        case 11: return "Luau";
+                        case 20:
+                        case 21: return "Trout Derby";
+                        case 28: return "Dance Of The Moonlight Jellies";
+                        default:
+                            return null;
+                    }
+                case "fall":
+                    switch (Game1.dayOfMonth)
+                    {
+                        case 16: return "Stardew Valley Fair";
+                        case 27: return "Spirits Eve";
+                        default: return null;
+                    }
+                case "winter":
+                    switch (Game1.dayOfMonth)
+                    {
+                        case 8: return "Festival Of Ice";
+                        case 12:
+                        case 13: return "Squid Fest";
+                        case 15:
+                        case 16:
+                        case 17: return "Beach Night Market";
+                        case 25: return "Feast Of The Winter Star";
+                        default:
+                            return null;
+                    }
+                default: return null;
+            }
+        }
+
+        /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// <br/>   The festival can be left at any time.
+        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayEggFestival
             => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth == 13;
@@ -19,6 +92,7 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: true
         /// <br/>   No real festival, no trigger
+        /// <br/>   Tested: Player disconnection, reconnection is possible
         /// </summary>
         public static bool IsTodayDesertFestival
             => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth >= 15 && Game1.dayOfMonth <= 17;
@@ -26,6 +100,8 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// <br/>   The end must be triggerd
+        /// <br/>   Tested: Player disconnection, visible, vote
         /// </summary>
         public static bool IsTodayFlowerDance
             => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth == 24;
@@ -33,6 +109,8 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// <br/>   The festival can be left at any time.
+        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayLuau
             => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth == 11;
@@ -40,6 +118,7 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: true
         /// <br/>   No real festival, no trigger
+        /// <br/>   Tested: Nothing to be tested
         /// </summary>
         public static bool IsTodayTroutDerby
             => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth >= 20 && Game1.dayOfMonth <= 21;
@@ -47,6 +126,8 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// <br/>   The festival can be left at any time.
+        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayDanceOfTheMoonlightJellies
             => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth == 28;
@@ -54,13 +135,17 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// <br/>   The festival can be left at any time. You must manually exit the event after you have triggered the next steps.
+        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayStardewValleyFair
             => Game1.currentSeason.EqualsIgnoreCase("fall") && Game1.dayOfMonth == 16;
 
         /// <summary>
-        /// <br/>   Time passes: true
+        /// <br/>   Time passes: false
         /// <br/>   It's a festival, but you can just leave whenever you want, no trigger
+        /// <br/>   The festival can be left at any time.
+        /// <br/>   Tested: Player disconnection, left normal
         /// </summary>
         public static bool IsTodaySpiritsEve
             => Game1.currentSeason.EqualsIgnoreCase("fall") && Game1.dayOfMonth == 27;
@@ -68,6 +153,8 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// <br/>   The festival can be left at any time.
+        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayFestivalOfIce
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth == 8;
@@ -75,6 +162,7 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: true
         /// <br/>   No real festival, no trigger
+        /// <br/>   Tested: Player disconnection, reconnection is possible
         /// </summary>
         public static bool IsTodaySquidFest
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth >= 12 && Game1.dayOfMonth <= 13;
@@ -82,6 +170,7 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: true
         /// <br/>   No real festival, no trigger
+        /// <br/>   Tested: Player disconnection, reconnection is possible
         /// </summary>
         public static bool IsTodayBeachNightMarket
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth >= 15 && Game1.dayOfMonth <= 17;
@@ -89,6 +178,8 @@ namespace DedicatedServer.Utils
         /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   It's a festival, but you can just leave whenever you want, no trigger
+        /// <br/>   The festival can be left at any time.
+        /// <br/>   Tested: Player disconnection, left normal
         /// </summary>
         public static bool IsTodayFeastOfTheWinterStar
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth == 25;

--- a/DedicatedServer/Utils/Festivals.cs
+++ b/DedicatedServer/Utils/Festivals.cs
@@ -10,28 +10,6 @@ namespace DedicatedServer.Utils
         #region Festivals
 
         /// <summary>
-        ///         Find out if there's a specific festival taking place today.
-        /// <br/>   The original functions are:
-        /// <br/>   <see cref="Utility.isFestivalDay()"/>
-        /// <br/>   <see cref="Utility.IsPassiveFestivalDay()"/>
-        /// </summary>
-        public static bool IsTodaySpecificFestival
-        { 
-            get
-            {
-                var day = Game1.dayOfMonth;
-                return Game1.currentSeason switch
-                {
-                    "spring" => day is 13 or 15 or 16 or 17 or 24,
-                    "summer" => day is 11 or 20 or 21 or 28,
-                    "fall" => day is 16 or 27,
-                    "winter" => day is 8 or 12 or 13 or 15 or 16 or 17 or 25,
-                    _ => false
-                };
-            }
-        }
-
-        /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
         /// </summary>
@@ -153,7 +131,26 @@ namespace DedicatedServer.Utils
             }
         }
 
-#endregion
+        #endregion
+
+        /// <summary>
+        ///         Get whether there's a festival scheduled for today in any location.
+        /// <br/>   
+        /// <br/>   It's better to read the static field (<see cref="Game1.weatherIcon"/>)
+        /// <br/>   than to call the function that set the field; <see cref="StardewValley.Utility.isFestivalDay(int, Season, string)"/>.
+        /// <br/>  
+        /// <br/>   This doesn't match passive festivals like the Night Market; <see cref="StardewValley.Utility.IsPassiveFestivalDay"/> for those.
+        /// </summary>
+        /// <returns>
+        ///         true : If today is a festival day
+        /// <br/>   false: If today is not a festival day</returns>
+        public static bool IsFestivalDay()
+        {
+            return 1 == Game1.weatherIcon;
+        }
+
+
+        #region No longer in use, but there are still some good examples
 
         public static bool IsWaitingToAttend()
         {
@@ -164,10 +161,14 @@ namespace DedicatedServer.Utils
         {
             return MainController.GetNumberReady("festivalStart") == (numOtherPlayers + (IsWaitingToAttend() ? 1 : 0));
         }
-        
+
         public static bool ShouldAttend(int numOtherPlayers)
         {
-            return numOtherPlayers > 0 && OthersWaitingToAttend(numOtherPlayers) && Utility.isFestivalDay() && !IsTodayBeachNightMarket && Game1.timeOfDay >= GetFestivalStartTime() && Game1.timeOfDay <= GetFestivalEndTime();
+            return
+                numOtherPlayers > 0 &&
+                OthersWaitingToAttend(numOtherPlayers) &&
+                false == IsTodayBeachNightMarket &&
+                IsTheFestivalGoingOn();
         }
 
         public static bool IsWaitingToLeave()
@@ -185,17 +186,51 @@ namespace DedicatedServer.Utils
             return Game1.isFestival() && OthersWaitingToLeave(numOtherPlayers);
         }
 
-        public static int GetFestivalStartTime()
-            => Utility.getStartTimeOfFestival();
+        #endregion
 
+        /// <summary>
+        /// Checks if the festival is ready to begin
+        /// </summary>
+        /// <returns>
+        ///         true : The festival is ready to begin
+        /// <br/>   false: The festival is being organized.</returns>
+        public static bool IsTheFestivalGoingOn()
+        {
+            return IsFestivalDay() &&
+                Game1.timeOfDay >= GetFestivalStartTime() &&
+                Game1.timeOfDay <= GetFestivalEndTime();
+        }
+
+        /// <summary>
+        /// Gets the start time of the festival
+        /// </summary>
+        /// <returns>Start time of the festival, or -1 if there is no festival today</returns>
+        public static int GetFestivalStartTime()
+        {
+            return Utility.getStartTimeOfFestival();
+        }
+
+        /// <summary>
+        /// Gets the end time of the festival
+        /// </summary>
+        /// <returns>End time of the festival, or -1 if there is no festival today</returns>
         public static int GetFestivalEndTime()
         {
-            if (Game1.weatherIcon == 1)
-            {
-                return Convert.ToInt32(Game1.temporaryContent.Load<Dictionary<string, string>>("Data\\Festivals\\" + Game1.currentSeason + Game1.dayOfMonth)["conditions"].Split('/')[1].Split(' ')[1]);
-            }
+            if (false == IsFestivalDay()) { return -1; }
 
-            return -1;
+            return Convert.ToInt32(
+                Game1.temporaryContent.Load<Dictionary<string, string>>("Data\\Festivals\\" + Game1.currentSeason + Game1.dayOfMonth)["conditions"].Split('/')[1].Split(' ')[1]);
+        }
+
+        /// <summary>
+        /// Gets the location of the festival
+        /// </summary>
+        /// <returns>Location of the festival, or null if there is no festival today</returns>
+        public static string GetLocationOfFestival()
+        {
+            if (false == IsFestivalDay()) { return null; }
+
+            return Game1.temporaryContent.Load<Dictionary<string, string>>("Data\\Festivals\\" + Game1.currentSeason + Game1.dayOfMonth)["conditions"].Split('/')[0];
         }
     }
 }

--- a/DedicatedServer/Utils/Festivals.cs
+++ b/DedicatedServer/Utils/Festivals.cs
@@ -116,11 +116,7 @@ namespace DedicatedServer.Utils
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth == 25;
 
         /// <summary>
-        /// Don't enable chat box on spirit's eve nor feast of the winter star
-        /// 
-        /// OLD:
-        ///  if ((Game1.currentSeason != "fall" || Game1.dayOfMonth != 27) &&
-        ///  (Game1.currentSeason != "winter" || Game1.dayOfMonth != 25) )
+        /// Only turn on the chat box when necessary.
         /// </summary>
         public static bool IsHostDecidingNextStep
         {
@@ -163,6 +159,7 @@ namespace DedicatedServer.Utils
         {
             return MainController.IsReady("festivalStart");
         }
+
         public static bool OthersWaitingToAttend(int numOtherPlayers)
         {
             return MainController.GetNumberReady("festivalStart") == (numOtherPlayers + (IsWaitingToAttend() ? 1 : 0));
@@ -170,7 +167,7 @@ namespace DedicatedServer.Utils
         
         public static bool ShouldAttend(int numOtherPlayers)
         {
-            return numOtherPlayers > 0 && OthersWaitingToAttend(numOtherPlayers) && Utility.isFestivalDay() && !IsTodayBeachNightMarket && Game1.timeOfDay >= Utility.getStartTimeOfFestival() && Game1.timeOfDay <= getFestivalEndTime();
+            return numOtherPlayers > 0 && OthersWaitingToAttend(numOtherPlayers) && Utility.isFestivalDay() && !IsTodayBeachNightMarket && Game1.timeOfDay >= GetFestivalStartTime() && Game1.timeOfDay <= GetFestivalEndTime();
         }
 
         public static bool IsWaitingToLeave()
@@ -188,7 +185,10 @@ namespace DedicatedServer.Utils
             return Game1.isFestival() && OthersWaitingToLeave(numOtherPlayers);
         }
 
-        private static int getFestivalEndTime()
+        public static int GetFestivalStartTime()
+            => Utility.getStartTimeOfFestival();
+
+        public static int GetFestivalEndTime()
         {
             if (Game1.weatherIcon == 1)
             {

--- a/DedicatedServer/Utils/Festivals.cs
+++ b/DedicatedServer/Utils/Festivals.cs
@@ -79,20 +79,18 @@ namespace DedicatedServer.Utils
                 default: return null;
             }
         }
-
+        
         /// <summary>
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
         /// <br/>   The festival can be left at any time.
-        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayEggFestival
             => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth == 13;
 
         /// <summary>
         /// <br/>   Time passes: true
-        /// <br/>   No real festival, no trigger
-        /// <br/>   Tested: Player disconnection, reconnection is possible
+        /// <br/>   No real festival, no trigger, reconnection is possible
         /// </summary>
         public static bool IsTodayDesertFestival
             => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth >= 15 && Game1.dayOfMonth <= 17;
@@ -101,7 +99,6 @@ namespace DedicatedServer.Utils
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
         /// <br/>   The end must be triggerd
-        /// <br/>   Tested: Player disconnection, visible, vote
         /// </summary>
         public static bool IsTodayFlowerDance
             => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth == 24;
@@ -110,15 +107,13 @@ namespace DedicatedServer.Utils
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
         /// <br/>   The festival can be left at any time.
-        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayLuau
             => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth == 11;
 
         /// <summary>
         /// <br/>   Time passes: true
-        /// <br/>   No real festival, no trigger
-        /// <br/>   Tested: Nothing to be tested
+        /// <br/>   No real festival, no trigger, reconnection is possible
         /// </summary>
         public static bool IsTodayTroutDerby
             => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth >= 20 && Game1.dayOfMonth <= 21;
@@ -127,7 +122,6 @@ namespace DedicatedServer.Utils
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
         /// <br/>   The festival can be left at any time.
-        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayDanceOfTheMoonlightJellies
             => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth == 28;
@@ -136,7 +130,6 @@ namespace DedicatedServer.Utils
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
         /// <br/>   The festival can be left at any time. You must manually exit the event after you have triggered the next steps.
-        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayStardewValleyFair
             => Game1.currentSeason.EqualsIgnoreCase("fall") && Game1.dayOfMonth == 16;
@@ -145,7 +138,6 @@ namespace DedicatedServer.Utils
         /// <br/>   Time passes: false
         /// <br/>   It's a festival, but you can just leave whenever you want, no trigger
         /// <br/>   The festival can be left at any time.
-        /// <br/>   Tested: Player disconnection, left normal
         /// </summary>
         public static bool IsTodaySpiritsEve
             => Game1.currentSeason.EqualsIgnoreCase("fall") && Game1.dayOfMonth == 27;
@@ -154,23 +146,20 @@ namespace DedicatedServer.Utils
         /// <br/>   Time passes: false
         /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
         /// <br/>   The festival can be left at any time.
-        /// <br/>   Tested: Player disconnection, visible, vote, left normal
         /// </summary>
         public static bool IsTodayFestivalOfIce
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth == 8;
 
         /// <summary>
         /// <br/>   Time passes: true
-        /// <br/>   No real festival, no trigger
-        /// <br/>   Tested: Player disconnection, reconnection is possible
+        /// <br/>   No real festival, no trigger, reconnection is possible
         /// </summary>
         public static bool IsTodaySquidFest
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth >= 12 && Game1.dayOfMonth <= 13;
 
         /// <summary>
         /// <br/>   Time passes: true
-        /// <br/>   No real festival, no trigger
-        /// <br/>   Tested: Player disconnection, reconnection is possible
+        /// <br/>   No real festival, no trigger, reconnection is possible
         /// </summary>
         public static bool IsTodayBeachNightMarket
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth >= 15 && Game1.dayOfMonth <= 17;
@@ -179,7 +168,6 @@ namespace DedicatedServer.Utils
         /// <br/>   Time passes: false
         /// <br/>   It's a festival, but you can just leave whenever you want, no trigger
         /// <br/>   The festival can be left at any time.
-        /// <br/>   Tested: Player disconnection, left normal
         /// </summary>
         public static bool IsTodayFeastOfTheWinterStar
             => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth == 25;
@@ -317,7 +305,7 @@ namespace DedicatedServer.Utils
         /// Gets the location of the festival
         /// </summary>
         /// <returns>Location of the festival, or null if there is no festival today</returns>
-        public static string GetLocationOfFestival()
+        public static string GetStandardLocationOfFestival()
         {
             if (false == IsFestivalDay()) { return null; }
 

--- a/DedicatedServer/Utils/Festivals.cs
+++ b/DedicatedServer/Utils/Festivals.cs
@@ -1,4 +1,5 @@
 ﻿using StardewValley;
+using StardewValley.Extensions;
 using System;
 using System.Collections.Generic;
 
@@ -6,15 +7,158 @@ namespace DedicatedServer.Utils
 {
     internal class Festivals
     {
-        private static int getFestivalEndTime()
-        {
-            if (Game1.weatherIcon == 1)
-            {
-                return Convert.ToInt32(Game1.temporaryContent.Load<Dictionary<string, string>>("Data\\Festivals\\" + Game1.currentSeason + Game1.dayOfMonth)["conditions"].Split('/')[1].Split(' ')[1]);
-            }
+        #region Festivals
 
-            return -1;
+        /// <summary>
+        ///         Find out if there's a specific festival taking place today.
+        /// <br/>   The original functions are:
+        /// <br/>   <see cref="Utility.isFestivalDay()"/>
+        /// <br/>   <see cref="Utility.IsPassiveFestivalDay()"/>
+        /// </summary>
+        public static bool IsTodaySpecificFestival
+        { 
+            get
+            {
+                var day = Game1.dayOfMonth;
+                return Game1.currentSeason switch
+                {
+                    "spring" => day is 13 or 15 or 16 or 17 or 24,
+                    "summer" => day is 11 or 20 or 21 or 28,
+                    "fall" => day is 16 or 27,
+                    "winter" => day is 8 or 12 or 13 or 15 or 16 or 17 or 25,
+                    _ => false
+                };
+            }
         }
+
+        /// <summary>
+        /// <br/>   Time passes: false
+        /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// </summary>
+        public static bool IsTodayEggFestival
+            => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth == 13;
+
+        /// <summary>
+        /// <br/>   Time passes: true
+        /// <br/>   No real festival, no trigger
+        /// </summary>
+        public static bool IsTodayDesertFestival
+            => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth >= 15 && Game1.dayOfMonth <= 17;
+
+        /// <summary>
+        /// <br/>   Time passes: false
+        /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// </summary>
+        public static bool IsTodayFlowerDance
+            => Game1.currentSeason.EqualsIgnoreCase("spring") && Game1.dayOfMonth == 24;
+
+        /// <summary>
+        /// <br/>   Time passes: false
+        /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// </summary>
+        public static bool IsTodayLuau
+            => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth == 11;
+
+        /// <summary>
+        /// <br/>   Time passes: true
+        /// <br/>   No real festival, no trigger
+        /// </summary>
+        public static bool IsTodayTroutDerby
+            => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth >= 20 && Game1.dayOfMonth <= 21;
+
+        /// <summary>
+        /// <br/>   Time passes: false
+        /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// </summary>
+        public static bool IsTodayDanceOfTheMoonlightJellies
+            => Game1.currentSeason.EqualsIgnoreCase("summer") && Game1.dayOfMonth == 28;
+
+        /// <summary>
+        /// <br/>   Time passes: false
+        /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// </summary>
+        public static bool IsTodayStardewValleyFair
+            => Game1.currentSeason.EqualsIgnoreCase("fall") && Game1.dayOfMonth == 16;
+
+        /// <summary>
+        /// <br/>   Time passes: true
+        /// <br/>   It's a festival, but you can just leave whenever you want, no trigger
+        /// </summary>
+        public static bool IsTodaySpiritsEve
+            => Game1.currentSeason.EqualsIgnoreCase("fall") && Game1.dayOfMonth == 27;
+
+        /// <summary>
+        /// <br/>   Time passes: false
+        /// <br/>   NPC the host must talk to in order to trigger the next step: Lewis
+        /// </summary>
+        public static bool IsTodayFestivalOfIce
+            => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth == 8;
+
+        /// <summary>
+        /// <br/>   Time passes: true
+        /// <br/>   No real festival, no trigger
+        /// </summary>
+        public static bool IsTodaySquidFest
+            => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth >= 12 && Game1.dayOfMonth <= 13;
+
+        /// <summary>
+        /// <br/>   Time passes: true
+        /// <br/>   No real festival, no trigger
+        /// </summary>
+        public static bool IsTodayBeachNightMarket
+            => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth >= 15 && Game1.dayOfMonth <= 17;
+
+        /// <summary>
+        /// <br/>   Time passes: false
+        /// <br/>   It's a festival, but you can just leave whenever you want, no trigger
+        /// </summary>
+        public static bool IsTodayFeastOfTheWinterStar
+            => Game1.currentSeason.EqualsIgnoreCase("winter") && Game1.dayOfMonth == 25;
+
+        /// <summary>
+        /// Don't enable chat box on spirit's eve nor feast of the winter star
+        /// 
+        /// OLD:
+        ///  if ((Game1.currentSeason != "fall" || Game1.dayOfMonth != 27) &&
+        ///  (Game1.currentSeason != "winter" || Game1.dayOfMonth != 25) )
+        /// </summary>
+        public static bool IsHostDecidingNextStep
+        {
+            get
+            {
+#if true
+                var day = Game1.dayOfMonth;
+                return Game1.currentSeason switch
+                {
+                    "spring" => day is 13 or 24, // 15 or 16 or 17 DesertFestival (no real festival)
+                    
+                    "summer" => day is 11 or 28, // 20 or 21, TroutDerby (no real festival)
+                    
+                    "fall" => day is 16, // 27 SpiritsEve (It's a festival, but you can just leave whenever you want)
+
+                    // 12 or 13 SquidFest (no real festival)
+                    // 15 or 16 or 17 BeachNightMarket (no real festival)
+                    // 25 FeastOfTheWinterStar (It's a festival, but you can just leave whenever you want)
+                    "winter" => day is 8,
+
+                    _ => false
+                };
+#else
+                // Like the old logic
+                if ((Game1.currentSeason != "fall" || Game1.dayOfMonth != 27) &&
+                    (Game1.currentSeason != "winter" || Game1.dayOfMonth != 25))
+                {
+                    // Don't enable chat box on spirit's eve nor feast of the winter star
+                    return true;
+                }
+
+                return false;
+#endif
+            }
+        }
+
+#endregion
+
         public static bool IsWaitingToAttend()
         {
             return MainController.IsReady("festivalStart");
@@ -23,26 +167,35 @@ namespace DedicatedServer.Utils
         {
             return MainController.GetNumberReady("festivalStart") == (numOtherPlayers + (IsWaitingToAttend() ? 1 : 0));
         }
-        private static bool isTodayBeachNightMarket()
-        {
-            return Game1.currentSeason.Equals("winter") && Game1.dayOfMonth >= 15 && Game1.dayOfMonth <= 17;
-        }
+        
         public static bool ShouldAttend(int numOtherPlayers)
         {
-            return numOtherPlayers > 0 && OthersWaitingToAttend(numOtherPlayers) && Utility.isFestivalDay() && !isTodayBeachNightMarket() && Game1.timeOfDay >= Utility.getStartTimeOfFestival() && Game1.timeOfDay <= getFestivalEndTime();
+            return numOtherPlayers > 0 && OthersWaitingToAttend(numOtherPlayers) && Utility.isFestivalDay() && !IsTodayBeachNightMarket && Game1.timeOfDay >= Utility.getStartTimeOfFestival() && Game1.timeOfDay <= getFestivalEndTime();
         }
 
         public static bool IsWaitingToLeave()
         {
             return MainController.IsReady("festivalEnd");
         }
+
         public static bool OthersWaitingToLeave(int numOtherPlayers)
         {
             return MainController.GetNumberReady("festivalEnd") == (numOtherPlayers + (IsWaitingToLeave() ? 1 : 0));
         }
+
         public static bool ShouldLeave(int numOtherPlayers)
         {
             return Game1.isFestival() && OthersWaitingToLeave(numOtherPlayers);
+        }
+
+        private static int getFestivalEndTime()
+        {
+            if (Game1.weatherIcon == 1)
+            {
+                return Convert.ToInt32(Game1.temporaryContent.Load<Dictionary<string, string>>("Data\\Festivals\\" + Game1.currentSeason + Game1.dayOfMonth)["conditions"].Split('/')[1].Split(' ')[1]);
+            }
+
+            return -1;
         }
     }
 }

--- a/DedicatedServer/Utils/Npc.cs
+++ b/DedicatedServer/Utils/Npc.cs
@@ -19,18 +19,6 @@ namespace DedicatedServer.Utils
                 : Game1.CurrentEvent.actors.FirstOrDefault(x => 0 == string.Compare(x.Name, name, StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
-        /// This is true for every menu, including a dialogue with an NPC
-        /// </summary>
-        /// <param name="farmer"></param>
-        /// <returns>
-        ///         true : A menu is open
-        /// <br/>   false: No menu is open</returns>
-        public static bool HasMenuOpen(Farmer farmer)
-        {
-            return farmer.hasMenuOpen.Value;
-        }
-
-        /// <summary>
         /// Calculates the distance between a farmer and an NPC
         /// </summary>
         /// <param name="farmer"></param>

--- a/DedicatedServer/Utils/Npc.cs
+++ b/DedicatedServer/Utils/Npc.cs
@@ -1,0 +1,148 @@
+﻿using Microsoft.Xna.Framework;
+using StardewValley;
+using System;
+using System.Linq;
+
+namespace DedicatedServer.Utils
+{
+    public class Npc
+    {
+        /// <summary>
+        ///         Get an NPC by its name.
+        /// <br/>   The location of the event can be found in <see cref="Game1.currentLocation;"/>
+        /// </summary>
+        /// <param name="name">The NPC name.</param>
+        /// <returns>Returns the matching NPC if found, else null.</returns>
+        public static NPC GetNpc(string name)
+            => (null == Game1.CurrentEvent)
+                ? Game1.getCharacterFromName(name, mustBeVillager: true)
+                : Game1.CurrentEvent.actors.FirstOrDefault(x => 0 == string.Compare(x.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// This is true for every menu, including a dialogue with an NPC
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <returns>
+        ///         true : A menu is open
+        /// <br/>   false: No menu is open</returns>
+        public static bool HasMenuOpen(Farmer farmer)
+        {
+            return farmer.hasMenuOpen.Value;
+        }
+
+        /// <summary>
+        /// Calculates the distance between a farmer and an NPC
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <param name="npc"></param>
+        /// <returns>The distance between a farmer and an NPC</returns>
+        public static double Distance(Farmer farmer, NPC npc)
+        {
+            if (farmer == null) { return double.MaxValue; }
+            if (npc == null) { return double.MaxValue; }
+
+            if (farmer.currentLocation.Name != npc.currentLocation.Name) { return double.MaxValue; }
+
+            return Distance(npc.Tile, farmer.Tile);
+        }
+
+        /// <summary>
+        /// Checks whether a farmer is near an NPC
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <param name="npc"></param>
+        /// <param name="range">Radius from the NPC</param>
+        /// <returns>
+        ///         true : The farmer is in the given range
+        /// <br/>   false: The farmer is outside the specified radius</returns>
+        public static bool IsFarmerWithinRange(Farmer farmer, NPC npc, double range)
+        {
+            if (farmer == null) { return false; }
+            if (npc == null) { return false; }
+
+            if (farmer.currentLocation.Name != npc.currentLocation.Name) { return false; }
+
+            return 0 >= Distance(npc.Tile, farmer.Tile) - range;
+        }
+
+        /// <summary>
+        /// Checks if a farmer is in front of an NPC
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <param name="npc"></param>
+        /// <param name="length">The distance from the NPC to the farmer</param>
+        /// <param name="width">The width to the right and left, expressed as the number of tiles</param>
+        /// <returns>
+        ///         true : The farmer is in the front of the NPC
+        /// <br/>   false: The farmer is not in the front of the NPC</returns>
+        /// <exception cref="Exception"></exception>
+        public static bool IsFarmerInFront(Farmer farmer, NPC npc, int length, int width)
+        {
+            if (farmer == null) { return false; }
+            if (npc == null) { return false; }
+
+            if (farmer.currentLocation.Name != npc.currentLocation.Name) { return false; }
+
+            bool inRange;
+            int xLow, xHeigh, yLow, yHeigh;
+
+            switch (npc.FacingDirection)
+            {
+                case Game1.up:
+                    xLow = (int)npc.Tile.X - width;
+                    xHeigh = (int)npc.Tile.X + width;
+                    yLow = (int)npc.Tile.Y - length;
+                    yHeigh = (int)npc.Tile.Y;
+
+                    inRange =
+                        xLow <= farmer.Tile.X && farmer.Tile.X <= xHeigh &&
+                        yLow <= farmer.Tile.Y && farmer.Tile.Y <= yHeigh;
+                    break;
+
+                case Game1.right:
+                    xLow = (int)npc.Tile.X;
+                    xHeigh = (int)npc.Tile.X + length;
+                    yLow = (int)npc.Tile.Y - width;
+                    yHeigh = (int)npc.Tile.Y + width;
+
+                    inRange =
+                        xLow <= farmer.Tile.X && farmer.Tile.X <= xHeigh &&
+                        yLow <= farmer.Tile.Y && farmer.Tile.Y <= yHeigh;
+                    break;
+
+                case Game1.down:
+                    xLow = (int)npc.Tile.X - width;
+                    xHeigh = (int)npc.Tile.X + width;
+                    yLow = (int)npc.Tile.Y;
+                    yHeigh = (int)npc.Tile.Y + length;
+
+                    inRange =
+                        xLow <= farmer.Tile.X && farmer.Tile.X <= xHeigh &&
+                        yLow <= farmer.Tile.Y && farmer.Tile.Y <= yHeigh;
+                    break;
+
+                case Game1.left:
+                    xLow = (int)npc.Tile.X - length;
+                    xHeigh = (int)npc.Tile.X;
+                    yLow = (int)npc.Tile.Y - width;
+                    yHeigh = (int)npc.Tile.Y + width;
+
+                    inRange =
+                        xLow <= farmer.Tile.X && farmer.Tile.X <= xHeigh &&
+                        yLow <= farmer.Tile.Y && farmer.Tile.Y <= yHeigh;
+                    break;
+
+                default:
+                    throw new Exception($"Value {npc.FacingDirection} is not supported as direction");
+            }
+
+            return inRange;
+        }
+
+        private static double Distance(Vector2 first, Vector2 second)
+        {
+            var difference = first - second;
+            return Math.Sqrt(difference.X * difference.X + difference.Y * difference.Y);
+        }
+    }
+}

--- a/DedicatedServer/manifest.json
+++ b/DedicatedServer/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "DedicatedServer",
   "Author": "Chris82111",
-  "Version": "1.2.3",
+  "Version": "1.2.4",
   "Description": "Dedicated (headless) server mod for Stardew Valley, powered by SMAPI. Turns the host into an automated bot. ",
   "UniqueID": "com.chris82111.dedicatedserver",
   "EntryDll": "DedicatedServer.dll",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 
 This mod provides a dedicated (headless) server for Stardew Valley, powered by SMAPI. It turns the host farmer into an automated bot to facilitate multiplayer gameplay.
 
+## In-Game Features
+
+### Festivals
+
+In some festivals, the host starts the event. Players must vote using `start` and `cancel`. Once all players have agreed to start, the host begins the event. Alternatively, a player can stand in front of Lewis. After 10 seconds, this is also considered consent to start. If a player steps back from Lewis or opens a menu, their consent is revoked.
+
 ## Configuration File
 
 Upon running SMAPI with the mod installed for the first time, a `config.json` file will be generated in the mod's folder. This file specifies which farm will be loaded on startup, farm creation options, host automation details, and other mod configuration options. Default values will be provided, which can then be modified. Here is an overview of the available settings:


### PR DESCRIPTION
- The way the host handles events has been converted to a state machine.
- All events have been tested.
- A second option for voting on the next step has been added:
  - A player can now stand in front of Lewis for 10 seconds to trigger "start" of the vote.
  - This resolves Problem #36.
  - If the player moves away, the vote is counted as "cancel".
  - If the farmer opens a menu or a conversation dialog appears, this is also counted as a cancellation.

Fixed bug:
  - The number of players was not updated during festivals, so the host did not trigger the next steps when players lost connection.
  - Now, if a player loses connection, the vote is adjusted and the player is removed.
  - If all players have lost connection, the host triggers the event and/or leaves the festival, goes to bed, and ends the day.
